### PR TITLE
Fixes search symbol centering

### DIFF
--- a/src/_input-groups.scss
+++ b/src/_input-groups.scss
@@ -84,7 +84,7 @@
 
 .input-inner-addon [class^="icon-16-"],
 .input-inner-addon [class*="icon-16-"] {
-	top: 24px;
+	top: 20px;
 }
 
 .input-inner-icon-helper {


### PR DESCRIPTION
Changes this

![image](https://user-images.githubusercontent.com/23219848/28934773-00f98ea2-7837-11e7-8348-99710fcb3505.png)

to this

![image](https://user-images.githubusercontent.com/23219848/28934834-3d337cb6-7837-11e7-9dc8-b09479033acd.png)

