### PR TITLE
Indent style of CSS is tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.css]
+indent_style = tab
+
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
This is a tiny PR that just tells the .editorconfig to do what you are already doing in your CSS files, which is to use tabs.