### PR TITLE
Consider linting of CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "repository": "wedeploy/marble",
   "homepage": "marblecss.com",
   "main": "index.js",
-  "license": "BSD",
+	"license": "BSD",
+	"scripts": {
+		"test": "stylelint src/*.scss --syntax scss"
+	},
   "dependencies": {
     "bootstrap-sass": "^3.3.6",
     "mathsass": "^0.9.5"
@@ -14,6 +17,11 @@
     "gulp": "^3.9.0",
     "gulp-iconfont": "^2.0.0",
     "gulp-iconfont-css": "0.0.9",
-    "gulp-sass": "^2.3.1"
+    "gulp-sass": "^2.3.1",
+    "stylelint": "^8.0.0",
+    "stylelint-config-dev": "^2.0.0"
+  },
+  "stylelint": {
+    "extends": "stylelint-config-dev"
   }
 }


### PR DESCRIPTION
This PR would add [Stylelint](https://stylelint.io/) to the project to help the team avoid errors and enforce consistent conventions across stylesheets. Stylelint is made in the image of [ESLint](https://eslint.org/), has been around for some time now, and gets consistent updates.

The biggest benefit to using a linter in a team is to keep the code highly accessible to the team, allowing them to focus on what the code is doing and less so on how it is formatted. You can configure linters to be as strict or as loose as you desire.

I’ve personally run your stylesheets against stylelint-config-dev because you are using extremely similar formatting.