### PR TITLE
Update topbars (dark, light variations) to use new landing styles

### DIFF
--- a/src/_topbars.scss
+++ b/src/_topbars.scss
@@ -1,253 +1,150 @@
 @import "variables";
 @import "mixins";
 
-/* (Mobile First)
-	Topbar DEFAULT
-	========================================================================== */
+/* Topbar
+/* ========================================================================== */
+
 .topbar {
-	background: $primary;
-
-	width: 100%;
-	height: auto;
-	min-height: 132px;
-	padding: 12px 20px;
-
+	align-items: center;
 	display: flex;
-	flex-direction: column;
-	justify-content: center;
+	flex-wrap: wrap;
+	font-size: 16px;
+	line-height: 24px;
+	padding: 12px 24px;
+	position: relative;
 
-	.topbar-logo {
-		display: flex;
+	@media (min-width: $screen-md-min) {
+		flex-wrap: nowrap;
+	}
+
+	&:not(.topbar-light) {
+		background-color: $primary;
+		color: $white;
+	}
+
+	&.topbar-light {
+		background-color: $white;
+		color: $primary;
+	}
+}
+
+/* Topbar: Logo
+/* ========================================================================== */
+
+.topbar-logo {
+	font-size: inherit;
+	font-weight: inherit;
+	margin: 0;
+}
+
+.topbar-logo-link {
+	color: inherit;
+	display: flex;
+
+	&:hover, &:focus {
+		color: inherit;
+	}
+}
+
+.topbar-logo-text {
+	display: block;
+	font-size: 14px;
+	line-height: 18px;
+	margin: 0 -12px;
+	padding: 9px 12px;
+
+	* + & {
+		margin-left: 0;
+	}
+}
+
+.topbar-logo-icon {
+	color: #00d46a;
+	display: block;
+	line-height: 36px;
+
+	:root & {
+		font-size: 36px;
+	}
+}
+
+.topbar-logo-image {
+	display: block;
+	height: 36px;
+	width: 36px;
+}
+
+/* Topbar: List
+/* ========================================================================== */
+
+.topbar-list-container {
+	margin-left: auto;
+}
+
+.topbar-list {
+	flex-basis: calc(100% + 24px * 2);
+	list-style-type: none;
+	margin: 12px -24px 0;
+	padding: 0;
+
+	@media (min-width: $screen-md-min) {
 		align-items: center;
-		align-self: center;
-
-		margin: 0 0 12px 0;
-		max-width: 100%;
-
-		.wedeploy-logo {
-			.deploy,
-			.liferay,
-			.version-container {
-				display: none;
-			}
-		}
-
-		.topbar-logo-link {
-			@include anim(color);
-			color: $white;
-			font-family: $font-primary;
-			font-weight: 700;
-			margin: 0;
-
-			display: flex;
-			flex-direction: row;
-			justify-content: center;
-			align-content: center;
-			align-items: center;
-
-			&:hover,
-			&:focus {
-				color: rgba($white, 0.6);
-			}
-
-			> *:last-child {
-				margin: 0;
-			}
-		}
-
-		.topbar-logo-image {
-			height: 36px;
-			margin: 0 12px 0 0;
-		}
-
-		.topbar-logo-icon {
-			color: $accent;
-			font-size: 24px;
-			line-height: 36px;
-			margin: 0 12px 0 0;
-		}
-	}
-
-	.topbar-logo-text {
-		font-family: $font-primary;
-		font-weight: 700;
-		font-size: 17px;
-		line-height: 36px;
-		margin: 0 12px 0 0;
-
-		flex-shrink: 1;
-	}
-
-	.topbar-list-container {
 		display: flex;
-		justify-content: center;
+		flex-basis: auto;
+		margin: 0 0 0 auto;
+	}
 
-		max-width: 100%;
+	&:not(.topbar-light) & {
+		background-color: $primary;
+	}
 
+	.topbar-light & {
+		background-color: $white;
+	}
+
+	&.toggler-expanded {
+		@media (max-width: 839px) {
+			max-height: 100vh;
+			padding: 12px 0;
+			visibility: visible;
+		}
+	}
+}
+
+.topbar-link {
+	color: inherit;
+	display: block;
+	font-size: 18px;
+	line-height: 24px;
+	padding: 9px 24px;
+
+	@media (min-width: $screen-md-min) {
+		font-size: 14px;
+		line-height: 18px;
+		padding: 9px 12px;
+	}
+
+	&:hover, &:focus {
+		color: inherit;
+	}
+
+	&.btn-transparent {
+		margin-left: 24px;
+		margin-top: 18px;
 		padding: 0;
-		margin: 0;
-	}
 
-	.topbar-list {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
-		justify-content: center;
-		align-items: center;
-		align-content: center;
-
-		font-size: 0;
-		list-style: none;
-
-		padding: 0;
-		margin: 0;
-
-		.topbar-item {
-			align-self: center;
-			display: inline-block;
-			height: 36px;
-			margin: 0 20px;
-
-			&:last-child {
-				margin: 0 0 0 20px;
-			}
-
-			.topbar-link {
-				@include anim(color);
-
-				white-space: nowrap;
-
-				font-size: 16px;
-				font-family: $font-primary;
-				font-weight: 700;
-				color: rgba($white, 0.4);
-				line-height: 36px;
-
-				&.topbar-link-selected,
-				&:hover {
-					color: rgba($white, 0.8);
-				}
-			}
+		@media (min-width: $screen-md-min) {
+			margin-left: 6px;
+			margin-top: 0;
 		}
 
-		.topbar-avatar {
-			.avatar-initials {
-				background: $accent;
-				color: $white;
-			}
-
-			.dropdown-menu {
-				border-top: 0;
-				border-top-left-radius: 0;
-				border-top-right-radius: 0;
-				margin: 12px 0 0 -102px;
-			}
+		& > object {
+			vertical-align: top;
 		}
 	}
 
-}
-
-/* Topbar Fixed
-	========================================================================== */
-
-.topbar.topbar-fixed {
-	top: 0;
-	left: 0;
-	z-index: 9999;
-
-	@media (min-width: $screen-md-min) {
-		position: fixed;
+	& .avatar-initials {
+		border-radius: 50%;
+		display: inline-block;
 	}
-}
-
-/* Topbar Large
-	========================================================================== */
-.topbar.topbar-large {
-
-	.topbar-logo {
-
-		.topbar-logo-image {
-			height: 48px;
-		}
-
-		.topbar-logo-text {
-			font-size: 22px;
-		}
-
-		.topbar-logo-icon {
-			font-size: 36px;
-			line-height: 48px;
-		}
-
-	}
-}
-
-/* Topbar DEFAULT NOT Mobile Site
-	========================================================================== */
-.topbar {
-	@media (min-width: $screen-md-min) {
-		height: 60px;
-		min-height: 60px;
-
-		flex-direction: row;
-		justify-content: space-between;
-
-		.topbar-logo {
-			align-self: flex-start;
-			margin: 0 12px 0 0;
-
-			.wedeploy-logo {
-				.deploy,
-				.liferay,
-				.version-container {
-					display: inline-block;
-				}
-			}
-		}
-
-		.topbar-list-container {
-			justify-content: flex-end;
-		}
-
-		.topbar-list {
-			margin: 0 0 0 auto;
-		}
-	}
-}
-
-/* Topbar LARGE NOT Mobile Site
-	========================================================================== */
-.topbar.topbar-large {
-	@media (min-width: $screen-md-min) {
-		height: 84px;
-		min-height: 84px;
-
-		padding: 24px 20px 12px;
-	}
-}
-
-/* Topbar LIGHT
-	========================================================================== */
-.topbar.topbar-light {
-	background: white;
-
-	.topbar-logo {
-		.topbar-logo-link {
-			color: rgba($primary, 0.8);
-		}
-	}
-
-	.topbar-list {
-		.topbar-item {
-			.topbar-link {
-				color: rgba($primary, 0.4);
-
-				&.topbar-link-selected,
-				&:hover {
-					color: rgba($primary, 0.6);
-				}
-			}
-		}
-	}
-
 }


### PR DESCRIPTION
Some differences from between this minor update to the topbars and the current landing page:

- Uses **Helvetica Neue** font instead of **Circular Std** font
- Displays full width instead of the 1440px width
- Has no dropdown states
- Uses thinner vertical padding around the menu so that alignment remains the same on marblecss.com