### PR TITLE
Update SCSS files to pass all stylelint tests

### DIFF
--- a/packages/marble/package.json
+++ b/packages/marble/package.json
@@ -35,6 +35,9 @@
     "last 2 safari versions"
   ],
   "stylelint": {
-    "extends": "stylelint-config-dev"
+    "extends": "stylelint-config-dev",
+    "rules": {
+      "indentation": 2
+    }
   }
 }

--- a/packages/marble/src/_alerts.scss
+++ b/packages/marble/src/_alerts.scss
@@ -6,35 +6,31 @@
    ========================================================================== */
 
 .alert {
+  align-content: center;
+  align-items: center;
+  background-color: $white;
   border: 0;
   border-radius: 4px;
-  background-color: white;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  color: rgba($primary, .8);
-
-  position: fixed;
   bottom: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .2);
+  color: rgba($primary, .8);
+  display: inline-flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
   left: 12px;
-  z-index: 1051;
-
   margin: 0;
-  padding: 6px 12px;
   max-width: calc(100% - 24px);
   min-height: 60px;
+  padding: 6px 12px;
+  position: fixed;
+  z-index: 1051;
 
   @media (min-width: $screen-sm-min) {
-    left: 48px;
     bottom: 48px;
+    left: 48px;
     max-width: calc(100% - 96px);
     padding: 12px 24px;
   }
-
-  display: inline-flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: flex-start;
-  align-content: center;
-  align-items: center;
 }
 
 .alert-danger {
@@ -46,36 +42,33 @@
 }
 
 .alert-body {
-  display: inline-flex;
-  flex-direction: row;
   align-content: center;
   align-items: center;
+  display: inline-flex;
   flex: 0 1 auto;
-
-  min-height: 24px;
-  margin: 0;
-
+  flex-direction: row;
   font-family: $font-primary;
   font-size: 13px;
   font-weight: 700;
   line-height: 18px;
+  margin: 0;
+  min-height: 24px;
   text-align: left;
 }
 
 .alert .close {
-  @include anim(color);
   color: rgba($primary, .4);
+  font-size: 24px;
+  height: 24px;
+  line-height: 24px;
+  margin: 0 0 0 12px;
+  min-width: 13px;
   opacity: 1;
   outline: none;
-
-  height: 24px;
-  min-width: 13px;
-  margin: 0 0 0 12px;
   padding: 0;
-
-  font-size: 24px;
-  line-height: 24px;
   text-shadow: none;
+
+  @include anim(color);
 
   @media (min-width: $screen-sm-min) {
     margin: 0 0 0 24px;
@@ -104,21 +97,19 @@
 }
 
 .alert-undo-link {
-  @include anim(color);
-
   background: transparent;
-  border-width: 0px;
+  border-width: 0;
   color: $accent;
-
   font-family: $font-primary;
   font-size: 13px;
   font-weight: 700;
   line-height: 18px;
-
   margin: 0 0 0 12px;
   outline: none;
   padding: 0;
   text-transform: uppercase;
+
+  @include anim(color);
 
   @media (min-width: $screen-sm-min) {
     margin: 0 0 0 24px;
@@ -146,7 +137,7 @@
 }
 
 .animated {
-  animation-duration: 0.2s;
+  animation-duration: .2s;
   animation-fill-mode: both;
 }
 
@@ -154,37 +145,35 @@
    ========================================================================== */
 
 .alert.alert-inline {
-  position: static;
-  box-shadow: none;
-  bottom: auto;
-  left: auto;
-  padding: 12px;
-  margin-bottom: 12px;
-  height: auto;
-  text-align: left;
-  width: 100%;
-  max-width: 100%;
-
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: flex-start;
   align-content: center;
   align-items: center;
+  bottom: auto;
+  box-shadow: none;
+  display: flex;
+  flex-flow: row nowrap;
+  height: auto;
+  justify-content: flex-start;
+  left: auto;
+  margin-bottom: 12px;
+  max-width: 100%;
+  padding: 12px;
+  position: static;
+  text-align: left;
+  width: 100%;
 
   &.alert-inline--vcenter {
     > .close {
-      margin-top: 6px;
       align-self: flex-start;
+      margin-top: 6px;
     }
   }
 
   > * {
     display: inline-block;
+    flex: 0 1 auto;
     line-height: 24px;
     margin: 0 12px 0 0;
     min-height: 24px;
-    flex: 0 1 auto;
 
     &:last-child {
       margin: 0;
@@ -192,26 +181,25 @@
   }
 
   > .alert-body {
+    color: rgba($primary, .8);
     flex-grow: 1;
     flex-shrink: 1;
-
-    color: rgba($primary, 0.8);
     font-family: $font-secondary;
     font-weight: 400;
-
-    white-space: normal;
     overflow: visible;
     text-overflow: clip;
+    white-space: normal;
 
     > .alert-link {
-      @include anim(all);
-      border-bottom: 1px dashed rgba($primary, 0.4);
-      color: rgba($primary, 0.8);
+      border-bottom: 1px dashed rgba($primary, .4);
+      color: rgba($primary, .8);
       font-weight: 700;
 
+      @include anim(all);
+
       &:hover {
+        border-bottom: 1px dashed rgba($accent, .4);
         color: $accent;
-        border-bottom: 1px dashed rgba($accent, 0.4);
       }
     }
   }
@@ -222,17 +210,17 @@
 }
 
 .alert.alert-inline.alert-warning {
-  background: rgba($color-yellow, 0.1);
+  background: rgba($color-yellow, .1);
 
-  > span[class*="icon-16"]{
+  > span[class*="icon-16"] {
     color: $color-yellow;
   }
 }
 
 .alert.alert-inline.alert-danger {
-  background: rgba($color-red, 0.1);
+  background: rgba($color-red, .1);
 
-  > span[class*="icon-16"]{
+  > span[class*="icon-16"] {
     color: $color-red;
   }
 }
@@ -241,7 +229,7 @@
    ========================================================================== */
 
 .alert.alert-dark {
-  background-color: rgba($primary, 0.9);
+  background-color: rgba($primary, .9);
   color: $white;
   height: auto;
   line-height: 24px;
@@ -251,7 +239,7 @@
     color: $white;
 
     &:hover {
-      color: rgba($white, 0.6);
+      color: rgba($white, .6);
     }
   }
 }

--- a/packages/marble/src/_animations.scss
+++ b/packages/marble/src/_animations.scss
@@ -14,13 +14,13 @@
 
 @keyframes fadeInToRight {
   0% {
-    transform: translate3d(-252px, 0, 0);
     opacity: 0;
+    transform: translate3d(-252px, 0, 0);
   }
 
   100% {
-    transform: translate3d(0, 0, 0);
     opacity: 1;
+    transform: translate3d(0, 0, 0);
   }
 }
 
@@ -53,8 +53,8 @@
   }
 
   100% {
-    visibility: hidden;
     transform: translate3d(-100%, 0, 0);
+    visibility: hidden;
   }
 }
 
@@ -75,7 +75,7 @@
   }
 
   100% {
-    visibility: hidden;
     transform: translate3d(0, 300%, 0);
+    visibility: hidden;
   }
 }

--- a/packages/marble/src/_autocompletes.scss
+++ b/packages/marble/src/_autocompletes.scss
@@ -3,14 +3,15 @@
    ========================================================================== */
 
 .autocomplete {
-  @include box-shadow(0 2px 8px rgba(0, 0, 0, 0.1));
-  background: white;
+  background: $white;
   border: 1px transparent;
-  margin-top: 0px;
+  border-radius: 4px;
+  margin-top: 0;
   overflow: hidden;
   position: absolute;
   z-index: $zindex-modal;
-  border-radius: 4px;
+
+  @include box-shadow(0 2px 8px rgba(0, 0, 0, .1));
 
   .list {
     padding-bottom: 12px;
@@ -36,10 +37,7 @@
 }
 
 .autocomplete-topbar.autocomplete-bottom {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
+  border-radius: 0 0 4px 4px;
   margin-top: 22px;
 }
 
@@ -65,9 +63,10 @@
   }
 
   .listitem-link {
-    @include anim(background);
     display: block;
     padding: 23px 20px 32px;
+
+    @include anim(background);
 
     &:hover {
       background: rgba($accent, .1);
@@ -76,8 +75,8 @@
 
   .listitem-title {
     color: $primary;
-    font-size: 16px;
     font-family: $font-primary;
+    font-size: 16px;
     font-weight: 700;
   }
 

--- a/packages/marble/src/_avatars.scss
+++ b/packages/marble/src/_avatars.scss
@@ -12,24 +12,23 @@
 
 .avatar {
   display: inline-block;
-  position: relative;
   overflow: hidden;
-
+  position: relative;
   text-align: center;
   text-decoration: none;
 
   img {
-    width: inherit;
     height: inherit;
-    position: absolute;
     left: 0;
+    position: absolute;
     top: 0;
+    width: inherit;
     z-index: 1;
   }
 
   .avatar-initials {
+    border: 1px solid $white;
     box-sizing: border-box;
-    border: 1px solid white;
   }
 }
 
@@ -37,8 +36,8 @@
    ========================================================================== */
 
 .topbar .avatar .avatar-initials {
-  box-sizing: border-box;
   border: 1px solid $primary;
+  box-sizing: border-box;
 }
 
 /* Avatar - Sizes
@@ -51,28 +50,28 @@ $large  : 60px;
 $xlarge : 72px;
 
 .avatar-xsmall {
-  width: $xsmall;
   height: $xsmall;
+  width: $xsmall;
 }
 
 .avatar-small {
-  width: $small;
   height: $small;
+  width: $small;
 }
 
 .avatar-medium {
-  width: $medium;
   height: $medium;
+  width: $medium;
 }
 
 .avatar-large {
-  width: $large;
   height: $large;
+  width: $large;
 }
 
 .avatar-xlarge {
-  width: $xlarge;
   height: $xlarge;
+  width: $xlarge;
 }
 
 /* Avatar - Photo
@@ -111,28 +110,30 @@ $xlarge : 72px;
 
 .avatar-initials {
   background: rgba($primary, .3);
-  color: white;
+  color: $white;
   cursor: default;
   font-family: $font-primary;
   font-weight: 700;
-  text-transform: uppercase;
   margin: 0 auto;
+  text-transform: uppercase;
 }
 
 .avatar-initials:hover {
-  color: white;
+  color: $white;
 }
 
 /* Avatar - Number
    ========================================================================== */
 
 .avatar-number {
-  @extend .avatar;
-  @include anim(background);
   background: rgba($primary, .1);
   color: rgba($primary, .6);
   font-family: $font-primary;
   font-weight: 700;
+
+  @extend .avatar;
+
+  @include anim(background);
 }
 
 .avatar-number:hover {
@@ -183,55 +184,55 @@ $xlarge : 72px;
    ========================================================================== */
 
 .avatar-icon.avatar-xsmall img {
-  width: $xsmall/2;
   height: $xsmall/2;
   margin: $xsmall/4 auto;
+  width: $xsmall/2;
 }
 
 .avatar-icon.avatar-small img {
-  width: $small/2;
   height: $small/2;
   margin: $small/4 auto;
+  width: $small/2;
 }
 
 .avatar-icon.avatar-medium img {
-  width: $medium/2;
   height: $medium/2;
   margin: $medium/4 auto;
+  width: $medium/2;
 }
 
 .avatar-icon.avatar-large img {
-  width: $large/2;
   height: $large/2;
   margin: $large/4 auto;
+  width: $large/2;
 }
 
 .avatar-icon.avatar-xlarge img {
-  width: $xlarge/2;
   height: $xlarge/2;
   margin: $xlarge/4 auto;
+  width: $xlarge/2;
 }
 
 /* Avatar - Icon (Font)
    ========================================================================== */
 
-.avatar-icon.avatar-xsmall span{
+.avatar-icon.avatar-xsmall span {
   line-height: $xsmall;
 }
 
-.avatar-icon.avatar-small span{
+.avatar-icon.avatar-small span {
   line-height: $small;
 }
 
-.avatar-icon.avatar-medium span{
+.avatar-icon.avatar-medium span {
   line-height: $medium;
 }
 
-.avatar-icon.avatar-large span{
+.avatar-icon.avatar-large span {
   line-height: $large;
 }
 
-.avatar-icon.avatar-xlarge span{
+.avatar-icon.avatar-xlarge span {
   line-height: $xlarge;
 }
 
@@ -243,8 +244,8 @@ $xlarge : 72px;
 $icon12Medium: 36px;
 
 .avatar-icon-12.avatar-medium {
-  width: $icon12Medium;
   height: $icon12Medium;
+  width: $icon12Medium;
 }
 
 .avatar-icon-12.avatar-medium span {
@@ -255,8 +256,8 @@ $icon12Medium: 36px;
 $icon12Large: 72px;
 
 .avatar-icon-12.avatar-large {
-  width: $icon12Large;
   height: $icon12Large;
+  width: $icon12Large;
 }
 
 .avatar-icon-12.avatar-large span {
@@ -267,8 +268,8 @@ $icon12Large: 72px;
 $icon16Medium: 56px;
 
 .avatar-icon-16.avatar-medium {
-  width: $icon16Medium;
   height: $icon16Medium;
+  width: $icon16Medium;
 }
 
 .avatar-icon-16.avatar-medium span {
@@ -279,8 +280,8 @@ $icon16Medium: 56px;
 $icon16Large: 96px;
 
 .avatar-icon-16.avatar-large {
-  width: $icon16Large;
   height: $icon16Large;
+  width: $icon16Large;
 }
 
 .avatar-icon-16.avatar-large span {
@@ -302,46 +303,43 @@ $icon16Large: 96px;
 
 .avatar-container .avatar-photo,
 .avatar-container .avatar-initials {
-  position: absolute;
   left: 0;
+  position: absolute;
 }
 
 /* Avatar - background white with shadow and status colors
    ========================================================================== */
 
 .avatar.avatar-white,
-.avatar-initials.avatar-white
-.avatar-icon.avatar-white {
+.avatar-initials.avatar-white .avatar-icon.avatar-white {
   background: $white;
-  box-shadow: 0 2px 8px rgba($primary, 0.1);
+  box-shadow: 0 2px 8px rgba($primary, .1);
   color: rgba($primary, .8);
 }
 
 .avatar.avatar-success,
-.avatar-initials.avatar-success
-.avatar-icon.avatar-success {
+.avatar-initials.avatar-success .avatar-icon.avatar-success {
   background: $brand-success;
   color: $white;
 }
 
 .avatar.avatar-danger,
-.avatar-initials.avatar-danger
-.avatar-icon.avatar-danger {
+.avatar-initials.avatar-danger .avatar-icon.avatar-danger {
   background: $brand-danger;
   color: $white;
 }
 
 .avatar.avatar-primary,
-.avatar-initials.avatar-primary
-.avatar-icon.avatar-primary {
+.avatar-initials.avatar-primary .avatar-icon.avatar-primary {
   background: rgba($primary, .8);
   color: $white;
 }
 
 /* Avatar - We
    ========================================================================== */
+
 .avatar-initials.avatar-we {
-  text-transform: capitalize;
   font-family: $font-primary;
   font-weight: 600;
+  text-transform: capitalize;
 }

--- a/packages/marble/src/_box.scss
+++ b/packages/marble/src/_box.scss
@@ -3,21 +3,22 @@
    ========================================================================== */
 
 .box {
-  @include anim(box-shadow);
   background: $white;
+  border-radius: 4px;
+  box-shadow: 0 2px 12px rgba($primary, .12);
+  color: rgba($primary, .8);
   display: inline-block;
-  padding: 0 12px;
+  font-family: $font-primary;
+  font-size: 12px;
+  font-weight: 700;
   height: 36px;
   line-height: 36px;
-  font-size: 12px;
-  color: rgba($primary, 0.8);
-  box-shadow: 0 2px 12px rgba($primary, 0.12);
-  font-family: $font-primary;
-  font-weight: 700;
-  border-radius: 4px;
+  padding: 0 12px;
+
+  @include anim(box-shadow);
 
   &.show-custom-tooltip:hover {
-    box-shadow: 0 2px 8px rgba($primary, 0.2);
+    box-shadow: 0 2px 8px rgba($primary, .2);
   }
 
   .bullet {
@@ -28,16 +29,16 @@
 .box.box-img {
   margin: 18px 8px 0 0;
   padding: 0;
+  text-align: center;
   width: 36px;
-  text-align: center
 }
 
 .box.box-label {
-  color: rgba($primary, 0.8);
+  color: rgba($primary, .8);
   margin: 0;
   padding: 0 12px;
+  text-align: center;
   width: auto;
-  text-align: center
 }
 
 .box.box-icon {
@@ -45,34 +46,34 @@
   padding: 0;
 
   span {
-    line-height: 24px;
-    width: 24px;
-    text-align: center;
-    display: inline-block;
     color: $accent;
+    display: inline-block;
+    line-height: 24px;
+    text-align: center;
+    width: 24px;
   }
 }
 
 .box.box-plus {
   margin: 18px 8px 0 0;
   padding: 0;
-  width: 36px;
   text-align: center;
+  width: 36px;
 }
 
 .box.box-disabled {
+  color: rgba($primary, .4);
   margin: 18px 0 0;
-  color: rgba($primary, 0.4);
 }
 
 .box.box-project {
   margin: 18px 0 0;
 
   span {
-    line-height: 36px;
-    color: rgba($primary, 0.4);
+    color: rgba($primary, .4);
     display: inline-block;
     float: left;
+    line-height: 36px;
 
     &.icon-success {
       color: $brand-success;
@@ -88,7 +89,7 @@
   }
 
   span.label-status {
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
     margin-left: 12px;
   }
 }
@@ -101,11 +102,11 @@
   line-height: 24px;
 
   &.box--icon-label {
-    color: rgba($primary, 0.6);
+    color: rgba($primary, .6);
     margin: 12px 0 0;
 
     span {
-      color: rgba($primary, 0.5);
+      color: rgba($primary, .5);
       margin: 0 8px 0 0;
       position: relative;
       top: 1px;
@@ -113,9 +114,11 @@
       &.up {
         color: $brand-success;
       }
+
       &.down {
         color: $brand-danger;
       }
+
       &.warn {
         color: $brand-warning;
       }
@@ -136,15 +139,15 @@
    ========================================================================== */
 
 .bullet {
+  background: rgba($primary, .6);
   border-radius: 50%;
-  height: 10px;
-  width: 10px;
-  position: relative;
   display: inline-block;
   float: left;
-  margin-top: 7px;
+  height: 10px;
   margin-right: 8px;
-  background: rgba($primary, .6);
+  margin-top: 7px;
+  position: relative;
+  width: 10px;
 
   &.up {
     background: $accent;

--- a/packages/marble/src/_button-groups.scss
+++ b/packages/marble/src/_button-groups.scss
@@ -36,13 +36,13 @@
 }
 
 .btn-group-label {
-  @include anim(top);
   position: relative;
   top: 0;
+
+  @include anim(top);
 }
 
 .btn-group-icon {
-  @include anim(top);
   background: $white;
   border-radius: 50%;
   color: rgba($primary, .8);
@@ -51,6 +51,8 @@
   padding: 1px 2px 3px;
   position: absolute;
   top: 60px;
+
+  @include anim(top);
 }
 
 /* Selected

--- a/packages/marble/src/_buttons.scss
+++ b/packages/marble/src/_buttons.scss
@@ -5,10 +5,11 @@
    ========================================================================== */
 
 .btn {
-  @include button-size(0, 48px, 16px, 60px, 4px);
+  border: 0 solid transparent;
   font-family: $font-primary;
   font-weight: 600;
-  border: 0px solid transparent;
+
+  @include button-size(0, 48px, 16px, 60px, 4px);
 
   &,
   &:active,
@@ -30,15 +31,16 @@
 }
 
 .btn-default {
-  @include anim(all);
   background-color: rgba($primary, .1);
-  color: rgba($primary, 0.6);
+  color: rgba($primary, .6);
+
+  @include anim(all);
 
   &:hover,
   &:focus,
   &.focus {
     background-color: rgba($primary, .2);
-    color: rgba($primary, 0.6);
+    color: rgba($primary, .6);
   }
 
   &:active,
@@ -47,15 +49,16 @@
     &:focus,
     &.focus {
       background-color: rgba($primary, .2);
-      color: rgba($primary, 0.6);
+      color: rgba($primary, .6);
     }
   }
 }
 
 .btn-primary {
-  @include anim(all);
   background-color: rgba($primary, .8);
   color: $white;
+
+  @include anim(all);
 
   &:hover,
   &:focus,
@@ -73,7 +76,6 @@
       color: $white;
     }
   }
-
 }
 
 .btn-primary.disabled,
@@ -101,9 +103,10 @@ fieldset[disabled] .btn-primary {
 }
 
 .btn-success {
-  @include anim(all);
   background-color: $brand-success;
   color: $white;
+
+  @include anim(all);
 
   &:hover,
   &:focus,
@@ -124,9 +127,10 @@ fieldset[disabled] .btn-primary {
 }
 
 .btn-danger {
-  @include anim(all);
   background-color: $brand-danger;
   color: $white;
+
+  @include anim(all);
 
   &:hover,
   &:focus,
@@ -147,9 +151,10 @@ fieldset[disabled] .btn-primary {
 }
 
 .btn-accent {
-  @include anim(all);
   background-color: $accent;
   color: $white;
+
+  @include anim(all);
 
   &:hover,
   &:focus,
@@ -170,9 +175,10 @@ fieldset[disabled] .btn-primary {
 }
 
 .btn-inverse {
-  @include anim(all);
   background: $white;
   color: rgba($primary, .8);
+
+  @include anim(all);
 
   &:hover,
   &:focus,
@@ -193,9 +199,10 @@ fieldset[disabled] .btn-primary {
 }
 
 .btn-inverse-accent {
-  @include anim(all);
   background: $white;
   color: $accent;
+
+  @include anim(all);
 
   &:hover,
   &:focus,
@@ -216,9 +223,10 @@ fieldset[disabled] .btn-primary {
 }
 
 .btn-link {
-  @include anim(all);
   background: transparent;
   color: rgba($primary, .8);
+
+  @include anim(all);
 
   &:hover,
   &:focus,
@@ -267,10 +275,10 @@ fieldset[disabled] .btn-link {
 
 .btn span[class^="icon-16-"],
 .btn span[class*="icon-16-"] {
+  color: inherit;
   margin-right: 10px;
   position: relative;
   top: 2px;
-  color: inherit;
 }
 
 /* Sizes
@@ -290,16 +298,16 @@ fieldset[disabled] .btn-link {
 .btn-transparent {
   background: transparent;
   border: 0;
-  padding: 0;
   color: rgba($primary, .6);
+  padding: 0;
 
   &,
   &:active,
   &.active {
     &:focus,
     &.focus {
-      outline: none;
       color: rgba($primary, .8);
+      outline: none;
     }
   }
 }
@@ -308,13 +316,14 @@ fieldset[disabled] .btn-link {
    ========================================================================== */
 
 .btn-icon {
-  @include anim(all);
   background: none;
   border: 0;
   border-radius: 50%;
   color: rgba($primary, .6);
   height: 48px;
   width: 48px;
+
+  @include anim(all);
 
   &.btn-squared {
     border-radius: 4px;
@@ -323,8 +332,8 @@ fieldset[disabled] .btn-link {
   &:hover,
   &:focus,
   &.focus {
-    color: $accent;
     background: rgba($accent, .1);
+    color: $accent;
   }
 
   &,
@@ -332,8 +341,8 @@ fieldset[disabled] .btn-link {
   &.active {
     &:focus,
     &.focus {
-      color: $accent;
       background: rgba($accent, .1);
+      color: $accent;
       outline: none;
     }
   }

--- a/packages/marble/src/_checkbox.scss
+++ b/packages/marble/src/_checkbox.scss
@@ -4,8 +4,8 @@
 
 .checkbox-group {
   list-style: none;
-  padding: 0;
   margin-left: 0;
+  padding: 0;
 
   &.checkbox-group-inline {
     > .checkbox {
@@ -13,19 +13,18 @@
       margin-right: 24px;
 
       &:last-child {
-        margin-right: 0px;
+        margin-right: 0;
       }
     }
   }
 }
 
 .checkbox {
-  font-family: $font-secondary;
-  font-weight: inherit;
-  font-size: inherit;
-
-  line-height: 24px;
   display: block;
+  font-family: $font-secondary;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: 24px;
 }
 
 .checkbox {
@@ -34,13 +33,13 @@
 
 .checkbox label {
   color: inherit;
+  cursor: pointer;
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
-  cursor: pointer;
-  padding-left: 24px;
   margin: 0;
+  padding-left: 24px;
   top: 0;
 }
 
@@ -48,25 +47,26 @@
   display: none;
 }
 
-.checkbox input[type="checkbox"] + label:before {
-  @include anim(all);
-  color: rgba($primary, 0.8);
+.checkbox input[type="checkbox"] + label::before {
+  color: rgba($primary, .8);
   content: "\E017";
-  font-family: 'icon-16';
+  font-family: "icon-16";
   font-size: 24px;
-  font-weight: normal;
+  font-weight: 400;
+  left: 0;
   line-height: 24px;
   position: absolute;
-  left: 0;
   top: 0;
+
+  @include anim(all);
 }
 
-.checkbox input[type="checkbox"]:checked + label:before {
-  content: "\E015";
+.checkbox input[type="checkbox"]:checked + label::before {
   color: $accent;
+  content: "\E015";
 }
 
-.checkbox input[type="checkbox"]:indeterminate + label:before {
+.checkbox input[type="checkbox"]:indeterminate + label::before {
+  color: rgba($primary, .4);
   content: "\E016";
-  color: rgba($primary, 0.4);
 }

--- a/packages/marble/src/_content-body.scss
+++ b/packages/marble/src/_content-body.scss
@@ -3,12 +3,13 @@
    ========================================================================== */
 
 .content-body {
-  @include anim(box-shadow);
-  box-shadow: 0 2px 12px rgba($primary, .12);
-  border-radius: 4px;
-  padding: 24px 20px;
-  margin-bottom: 24px;
   background: $white;
+  border-radius: 4px;
+  box-shadow: 0 2px 12px rgba($primary, .12);
+  margin-bottom: 24px;
+  padding: 24px 20px;
+
+  @include anim(box-shadow);
 
   @media (max-width: $screen-sm-min) {
     padding: 12px;
@@ -19,8 +20,8 @@
   }
 
   .btn-container {
-    text-align: center;
     margin: 36px 0 24px;
+    text-align: center;
   }
 
   .btn {
@@ -34,11 +35,11 @@
   .content-body-title {
     color: rgba($primary, .8);
     font-family: $font-primary;
-    font-weight: 600;
     font-size: 19px;
-    padding: 0;
+    font-weight: 600;
     line-height: 36px;
     margin: 0 0 12px;
+    padding: 0;
 
     &.top-2b {
       margin: 36px 0 24px;
@@ -49,7 +50,7 @@
     }
 
     .icon-info {
-      color: rgba($primary, 0.4);
+      color: rgba($primary, .4);
       margin-left: 8px;
     }
   }
@@ -57,37 +58,40 @@
   .content-body-subtitle {
     color: rgba($primary, .6);
     font-family: $font-primary;
-    font-weight: 600;
     font-size: 16px;
-    padding: 0;
+    font-weight: 600;
     line-height: 24px;
     margin: 24px 0 12px;
+    padding: 0;
   }
 
   .content-link {
-    @include anim(color);
-    font-size: 12px;
-    line-height: 36px;
     color: $accent;
     font-family: $font-secondary;
+    font-size: 12px;
     font-weight: 700;
+    line-height: 36px;
+
+    @include anim(color);
 
     .icon {
-      @include anim(background);
       background: rgba($accent, .1);
       border-radius: 50%;
-      width: 24px;
-      height: 24px;
       display: inline-block;
+      height: 24px;
       line-height: 22px;
+      margin-left: 8px;
       text-align: center;
       vertical-align: middle;
-      margin-left: 8px;
+      width: 24px;
+
+      @include anim(background);
     }
 
     &:hover,
     &:focus {
       color: rgba($accent, .8);
+
       .icon {
         background: rgba($accent, .2);
       }
@@ -98,13 +102,14 @@
    ========================================================================== */
 
   &.content-body-data {
-    padding: 0;
     margin: 0;
+    padding: 0;
     position: relative;
 
     .data-header,
     .data-footer {
-      background: white;
+      animation: fadeIn .5s cubic-bezier(.3, 0, .3, 1) 0s 1 forwards;
+      background: $white;
       display: flex;
       justify-content: space-between;
       padding: 12px 20px;
@@ -114,51 +119,45 @@
         padding: 12px;
       }
 
-      animation: fadeIn 0.5s cubic-bezier(0.3, 0, 0.3, 1) 0s 1 forwards;
-
       &.align-left {
         justify-content: flex-start;
       }
     }
 
     .data-header {
-      z-index: 99;
       box-shadow: 0 2px 8px rgba($primary, .1);
+      z-index: 99;
 
       @media (max-width: $screen-sm-min) {
         flex-wrap: wrap;
       }
 
-      .table-header-left {
-        label {
-          margin: 0 12px 0 0;
-        }
+      .table-header-left label {
+        margin: 0 12px 0 0;
       }
 
-      .table-header-right {
-        .btn-icon {
-          margin-left: 10px;
+      .table-header-right .btn-icon {
+        margin-left: 10px;
 
-          &:first-child {
-            margin-left: 0px;
-          }
+        &:first-child {
+          margin-left: 0;
         }
       }
     }
 
     .data-footer {
+      bottom: -60px;
+      box-shadow: 0 0 8px rgba($primary, .1);
       height: 60px;
       position: absolute;
-      box-shadow: 0 0 8px rgba($primary, .1);
-      bottom: -60px;
       z-index: 98;
 
       .data-footer-right {
         .data-footer-dropdown,
         .data-footer-pagination {
           display: inline-block;
-          height: 36px;
           float: left;
+          height: 36px;
         }
 
         .data-footer-dropdown .dropdown {
@@ -172,7 +171,7 @@
         .data-footer-pagination {
           margin-left: 28px;
 
-          label {
+          label { /* stylelint-disable-line max-nesting-depth */
             margin: 0 10px;
             min-width: 140px;
             text-align: center;
@@ -181,58 +180,59 @@
       }
 
       &.data-footer-small {
-        height: 24px;
         bottom: -24px;
+        height: 24px;
       }
     }
 
     .dropdown {
       display: inline-block;
-      width: auto;
       max-width: 240px;
       min-width: 110px;
+      width: auto;
 
       @media (max-width: $screen-sm-min) {
+        margin-bottom: 12px;
+        margin-right: 0;
         max-width: 100%;
         min-width: 100%;
-        margin-right: 0px;
-        margin-bottom: 12px;
       }
 
       .btn {
+        font-size: 13px;
         height: 36px;
         line-height: 36px;
         padding: 0 32px 0 12px;
-        font-size: 13px;
-        width: 100%;
         text-align: left;
+        width: 100%;
 
         .instance-name {
-          @extend .truncate;
+          display: block;
           font-family: $font-primary;
           font-weight: 700;
-          display: block;
-          width: inherit;
           text-align: left;
+          width: inherit;
+
+          @extend .truncate;
         }
       }
 
       .icon-12-arrows,
       .icon-12-arrow-down-short {
-        line-height: 36px;
         display: inline-block;
+        line-height: 36px;
         position: absolute;
         right: 12px;
         top: 0;
       }
 
       .dropdown-menu {
-        z-index: 9999;
-        width: 200px;
+        margin: 0;
         max-height: 400px;
         overflow-y: auto;
         padding: 12px 0;
-        margin: 0;
+        width: 200px;
+        z-index: 9999;
 
         @media (max-width: $screen-sm-min) {
           max-width: 100%;
@@ -249,7 +249,6 @@
           @extend .truncate;
         }
       }
-
     }
   }
 
@@ -257,41 +256,39 @@
    ========================================================================== */
 
   .read-only {
-    width: 100%;
-    min-height: 60px;
-    background: $white;
-    box-shadow: 0 2px 8px rgba($primary, 0.1);
-    padding: 12px 20px;
-    border-radius: 4px;
-
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: space-between;
     align-content: center;
     align-items: center;
+    background: $white;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba($primary, .1);
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    min-height: 60px;
+    padding: 12px 20px;
+    width: 100%;
 
     .title {
-      @extend .truncate;
-
       color: rgba($primary, .8);
+      display: block;
+      flex: 0 1 auto;
+      flex: 1 0 auto;
+      font-family: $font-primary;
+      font-size: 14px;
+      font-weight: 600;
       line-height: 24px;
       margin-right: 20px;
-      flex: 0 1 auto;
-      font-size: 14px;
-      font-family: $font-primary;
-      font-weight: 600;
-      display: block;
-      flex: 1 0 auto;
+
+      @extend .truncate;
     }
   }
 
   .dropdown .icon-16-arrow-down-short {
-    position: absolute;
+    color: rgba($primary, .4);
     line-height: 58px;
+    position: absolute;
     right: 10px;
     top: 1px;
-    color: rgba($primary, .4);
   }
 
   .input-group,
@@ -319,42 +316,43 @@
     }
 
     span {
-      font-size: 12px;
-      font-family: $font-secondary;
-      font-weight: 600;
       color: rgba($primary, .6);
+      display: inline-block;
+      font-family: $font-secondary;
+      font-size: 12px;
+      font-weight: 600;
       line-height: 24px;
       margin-bottom: 12px;
-      display: inline-block;
     }
   }
 
   .content-table-row {
-    display: block;
-    padding: 12px 20px;
-    box-shadow: 0px 2px 12px rgba($primary, 0.12);
     border-radius: 4px;
-
-    margin: 0 0 24px 0;
+    box-shadow: 0 2px 12px rgba($primary, .12);
+    display: block;
+    margin: 0 0 24px;
+    padding: 12px 20px;
 
     &:last-child {
-      margin: 0 0 12px 0;
+      margin: 0 0 12px;
     }
 
     &.content-table-row--small {
       .avatar-small {
-        width: 24px;
         height: 24px;
-      }
-      .avatar-initials {
         width: 24px;
+      }
+
+      .avatar-initials {
         height: 24px;
         line-height: 24px;
+        width: 24px;
       }
     }
 
     .avatar-container {
       background: $white;
+
       img[src=""] {
         display: none;
       }
@@ -366,14 +364,14 @@
     }
 
     .avatar-initials {
+      background: rgba($primary, .8);
       border-radius: 4px;
-      background: rgba($primary, 0.8);
     }
 
     .row-item {
+      display: inline-block;
       flex: 0 1 auto;
       flex-shrink: 1;
-      display: inline-block;
       margin-right: 12px;
 
       &:last-child {
@@ -390,21 +388,21 @@
     }
 
     .title {
+      color: rgba($primary, .8);
       font-family: $font-primary;
-      font-weight: 600;
       font-size: 14px;
-      color: rgba($primary, 0.8);
-      text-align: left;
+      font-weight: 600;
       line-height: 36px;
+      text-align: left;
     }
 
     .subtitle {
+      color: rgba($primary, .6);
       font-family: $font-secondary;
-      font-weight: 600;
       font-size: 11px;
-      color: rgba($primary, 0.6);
-      text-align: left;
+      font-weight: 600;
       line-height: 24px;
+      text-align: left;
     }
 
     .box.box--small {
@@ -412,17 +410,17 @@
     }
 
     .dropdown {
-      width: 36px;
       height: 36px;
+      width: 36px;
 
       .btn.btn-icon {
-        width: 36px;
-        height: 36px;
-        padding: 0;
         background: $white;
-        font-family: "icon-16";
-        line-height: 36px;
         border-radius: 4px;
+        font-family: "icon-16";
+        height: 36px;
+        line-height: 36px;
+        padding: 0;
+        width: 36px;
 
         &:hover,
         &:focus {
@@ -431,9 +429,9 @@
       }
 
       .dropdown-menu {
+        left: auto;
         margin: 0;
         right: 0;
-        left: auto;
       }
     }
 
@@ -443,7 +441,6 @@
       float: none;
     }
   }
-
 }
 
 /* Customization
@@ -461,7 +458,6 @@
 
 .project-overview .content-body,
 .project-activity .content-body {
-
   .item-avatar {
     @media (max-width: $screen-sm-min) {
       display: none;
@@ -469,27 +465,23 @@
   }
 
   .activity-item .item-label {
-
     @media (max-width: $screen-sm-min) {
       width: calc(100% - 48px);
     }
   }
 }
 
-
 .container-hybrid,
 .container-hybrid-half {
-
   @media (max-width: $screen-sm-min) {
-    width: calc(100% - 24px);
     padding: 0 12px;
+    width: calc(100% - 24px);
   }
 
   @media (max-width: $screen-md-min) {
-    width: calc(100% - 16px);
     padding: 0 8px;
+    width: calc(100% - 16px);
   }
-
 }
 
 /* Not Found
@@ -509,8 +501,8 @@
 
   @media (max-width: $screen-sm-min) {
     height: 60px;
-    width: 60px;
     margin: 0 auto 12px;
+    width: 60px;
   }
 }
 
@@ -529,8 +521,8 @@
 .notfound-text {
   color: rgba($primary, .8);
   font-family: $font-primary;
-  font-weight: 700;
   font-size: 18px;
+  font-weight: 700;
 
   @media (max-width: $screen-sm-min) {
     font-size: 12px;

--- a/packages/marble/src/_content-footer.scss
+++ b/packages/marble/src/_content-footer.scss
@@ -4,15 +4,15 @@
 
 .content-footer {
   color: rgba($primary, .6);
-  margin-top: -12px;
-  text-align: center;
   line-height: 24px;
   margin-bottom: 24px;
+  margin-top: -12px;
+  text-align: center;
 }
 
 .content-footer .content-footer__link {
   color: $accent;
-  font-size: 13px;
   font-family: $font-primary;
+  font-size: 13px;
   font-weight: 600;
 }

--- a/packages/marble/src/_content-header.scss
+++ b/packages/marble/src/_content-header.scss
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 .content-header {
-  padding: 24px 0 36px;
   min-height: 48px;
+  padding: 24px 0 36px;
 
   @media (max-width: $screen-md-min) {
     padding: 24px 0;
@@ -15,63 +15,64 @@
   }
 
   .header-title {
-    @include anim(color);
-    @extend .truncate;
+    color: rgba($primary, .9);
+    display: block;
+    font-family: $font-primary;
+    font-size: 29px;
+    font-weight: 700;
     line-height: 48px;
-    text-align: center;
     margin: 0;
     padding: 0;
-    display: block;
-
-    font-family: $font-primary;
-    font-weight: 700;
-
-    font-size: 29px;
-    color: rgba($primary, 0.9);
-
     position: relative;
+    text-align: center;
     top: 2px;
 
+    @include anim(color);
+
+    @extend .truncate;
+
     span {
+      color: rgba($primary, .4);
+
       @include anim(color);
-      color: rgba($primary, 0.4);
     }
 
     @media (max-width: $screen-md-min) {
-      text-align: left;
       font-size: 23px;
       line-height: 36px;
+      text-align: left;
     }
 
     @media (max-width: $screen-sm-min) {
-      text-align: left;
       font-size: 19px;
       line-height: 36px;
+      text-align: left;
     }
   }
 
   a.header-title:hover {
     color: $accent;
+
     span {
       color: $accent;
     }
   }
 
   .btn-install {
+    font-family: $font-primary;
+    font-size: 13px;
+    font-weight: 700;
     height: 48px;
     line-height: 48px;
-    font-size: 13px;
     padding: 0 12px;
-    font-family: $font-primary;
-    font-weight: 700;
 
     span {
       display: inline-block;
+      float: left;
       line-height: 48px;
       margin-right: 12px;
       position: relative;
-      top: 0px;
-      float: left;
+      top: 0;
 
       @media (max-width: $screen-md-min) {
         height: 36px;
@@ -86,10 +87,10 @@
   }
 
   .nav-container {
+    align-content: center;
+    align-items: center;
     display: flex;
     justify-content: flex-start;
-    align-items:center;
-    align-content:center;
     width: 100%;
 
     &.nav-container-end {
@@ -97,6 +98,7 @@
 
       .avatar-status {
         margin-left: 8px;
+
         @media (max-width: $screen-md-min) {
           margin-left: 0;
           margin-right: 8px;
@@ -109,15 +111,15 @@
     }
 
     .avatar-status {
+      background: rgba($primary, .05);
       display: inline-block;
-      width: 48px;
       height: 48px;
       text-align: center;
-      background: rgba($primary, .05);
+      width: 48px;
 
       @media (max-width: $screen-sm-min) {
-        width: 36px;
         height: 36px;
+        width: 36px;
       }
 
       [class^="icon-16-"],
@@ -131,24 +133,24 @@
       }
 
       &.up {
+        background: rgba($brand-success, .1);
         color: $brand-success;
-        background: rgba($brand-success, 0.1);
       }
 
       &.down {
+        background: rgba($brand-danger, .1);
         color: $brand-danger;
-        background: rgba($brand-danger, 0.1);
       }
 
       &.warn {
+        background: rgba($brand-warning, .1);
         color: $brand-warning;
-        background: rgba($brand-warning, 0.1);
       }
 
       &.unknown,
       &.loading {
-        color: rgba($primary, 0.8);
-        background: rgba($primary, 0.1);
+        background: rgba($primary, .1);
+        color: rgba($primary, .8);
       }
     }
   }
@@ -158,45 +160,46 @@
     margin-left: 8px;
 
     .dropdown-menu {
-      margin: 0px 0 0 -120px;
+      margin: 0 0 0 -120px;
     }
   }
 
   .btn.btn-default.btn-icon,
   .dropdown.dropdown-last .btn-icon {
-    @include anim(all);
+    background: rgba($primary, .05);
     border-radius: 4px;
-    width: 48px;
-    height: 48px;
-    padding: 0;
-    margin: 0;
-    text-align: center;
     display: inline-block;
-    background: rgba($primary, 0.05);
+    height: 48px;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+    width: 48px;
+
+    @include anim(all);
 
     &:hover {
-      background: rgba($accent, 0.1);
+      background: rgba($accent, .1);
       color: $accent;
     }
 
     span {
-      line-height: 48px;
-      margin: 0px;
       display: block;
-      top: 1px;
       left: 1px;
+      line-height: 48px;
+      margin: 0;
+      top: 1px;
     }
   }
 
   .dropdown .btn.btn-default {
     border-radius: 4px;
+    font-family: $font-primary;
+    font-size: 13px;
+    font-weight: 700;
     height: 48px;
     line-height: 48px;
-    padding: 0 32px 0 12px;
     margin: 0;
-    font-size: 13px;
-    font-family: $font-primary;
-    font-weight: 700;
+    padding: 0 32px 0 12px;
     position: relative;
     text-align: left;
 
@@ -210,8 +213,9 @@
 
   .dropdown {
     .dropdown-menu {
-      margin: 0px;
+      margin: 0;
       padding: 12px 0;
+
       li,
       li:first-child,
       li:last-child {
@@ -223,14 +227,14 @@
 
 .create-project .content-header .header-title {
   @media (max-width: $screen-md-min) {
-    text-align: center;
     font-size: 23px;
     line-height: 48px;
+    text-align: center;
   }
 
   @media (max-width: $screen-sm-min) {
-    text-align: center;
     font-size: 19px;
     line-height: 48px;
+    text-align: center;
   }
 }

--- a/packages/marble/src/_content-placeholder.scss
+++ b/packages/marble/src/_content-placeholder.scss
@@ -12,28 +12,29 @@
   .content-placeholder__title {
     color: rgba($primary, .8);
     font-family: $font-primary;
-    font-weight: 700;
     font-size: 16px;
-    margin: 0;
+    font-weight: 700;
     line-height: 36px;
+    margin: 0;
   }
 
   .content-placeholder__subtitle {
     color: rgba($primary, .6);
     font-family: $font-secondary;
-    font-weight: 600;
     font-size: 12px;
-    margin: 0;
+    font-weight: 600;
     line-height: 24px;
+    margin: 0;
     position: relative;
     top: -6px;
   }
 
   .content-placeholder__link {
-    @include anim(color);
     color: $accent;
     font-size: 12px;
     font-weight: 600;
+
+    @include anim(color);
 
     &:hover,
     &:focus {
@@ -52,10 +53,10 @@
   }
 
   &.content-placeholder--logs {
+    left: 50%;
     padding: 0;
     position: absolute;
     top: 50%;
-    left: 50%;
     transform: translateX(-50%) translateY(-50%);
   }
 }

--- a/packages/marble/src/_content-tabs.scss
+++ b/packages/marble/src/_content-tabs.scss
@@ -5,8 +5,8 @@
 .content-tabs {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  padding: 12px 8px;
   margin-top: -24px;
+  padding: 12px 8px;
 
   @media (max-width: $screen-md-min) {
     padding: 12px 0;
@@ -32,11 +32,12 @@
     }
 
     a {
-      @include anim(color);
       color: rgba($primary, .6);
       font-family: $font-primary;
-      font-weight: 700;
       font-size: 15px;
+      font-weight: 700;
+
+      @include anim(color);
 
       &:hover,
       &:focus {

--- a/packages/marble/src/_datatable.scss
+++ b/packages/marble/src/_datatable.scss
@@ -7,9 +7,9 @@
   width: 100%;
 
   .table {
+    border: 0 solid $white;
     margin: 0;
     table-layout: auto;
-    border: 0px solid $white;
 
     tr {
       height: 36px;
@@ -18,52 +18,48 @@
       td {
         font-family: $font-mono;
         font-size: 13px;
-
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-
-        vertical-align: middle;
-
-        min-width: 140px;
+        letter-spacing: -.5px;
         max-width: 280px;
+        min-width: 140px;
+        overflow: hidden;
         padding: 0 20px;
-        letter-spacing: -0.5px;
+        text-overflow: ellipsis;
+        vertical-align: middle;
+        white-space: nowrap;
       }
 
       th {
-        font-weight: 700;
         color: $accent;
+        font-weight: 700;
         line-height: 34px;
         text-transform: none;
       }
 
       th:nth-child(odd) {
-        background: rgba($accent, 0.05);
+        background: rgba($accent, .05);
       }
 
       th:nth-child(even) {
-        background: rgba($accent, 0.1);
+        background: rgba($accent, .1);
       }
     }
 
     tr:nth-child(odd) {
-      background: rgba($primary, 0.00);
+      background: rgba($primary, 0);
     }
 
     tr:nth-child(even) {
-      background: rgba($primary, 0.02);
+      background: rgba($primary, .02);
     }
   }
 
   .datatable-type {
-    margin-left: 8px;
+    color: rgba($primary, .4);
     font-size: 10px;
-    color: rgba($primary, 0.4);
-    text-transform: capitalize;
-
+    margin-left: 8px;
     overflow: hidden;
     text-overflow: ellipsis;
+    text-transform: capitalize;
     white-space: nowrap;
   }
 
@@ -76,14 +72,14 @@
   .datatable-boolean,
   .datatable-object,
   .datatable-array {
+    color: rgba($primary, .6);
     font-weight: 500;
-    color: rgba($primary, 0.6);
   }
 
   .datatable-undefined,
   .datatable-null {
+    color: rgba($primary, .2);
     font-weight: 500;
-    color: rgba($primary, 0.2);
   }
 
   /* Reset Table Borders
@@ -91,48 +87,50 @@
 
   .table tr th,
   .table tr td {
-    border-right: 0px solid rgba($primary, .2);
-    border-bottom: 0px solid rgba($primary, .2);
+    border-bottom: 0 solid rgba($primary, .2);
+    border-right: 0 solid rgba($primary, .2);
   }
+
   .table tr th:first-child,
   .table tr td:first-child {
-    border-left: 0px solid rgba($primary, .2);
+    border-left: 0 solid rgba($primary, .2);
   }
+
   .table tr th:first-child,
   .table tr td:first-child {
-    border-left: 0px solid rgba($primary, .2);
+    border-left: 0 solid rgba($primary, .2);
   }
 
   .table tr th {
-    border-top: 0px solid rgba($primary, .2);
+    border-top: 0 solid rgba($primary, .2);
   }
 
   .table.no-header tr:first-child td {
-    border-top: 0px solid rgba($primary, .2);
+    border-top: 0 solid rgba($primary, .2);
   }
 
   .table tr:first-child th:first-child {
-    border-top-left-radius: 0px;
+    border-top-left-radius: 0;
   }
 
   .table.no-header tr:first-child td:first-child {
-    border-top-left-radius: 0px;
+    border-top-left-radius: 0;
   }
 
   .table tr:first-child th:last-child {
-    border-top-right-radius: 0px;
+    border-top-right-radius: 0;
   }
 
   .table.no-header tr:first-child td:last-child {
-    border-top-right-radius: 0px;
+    border-top-right-radius: 0;
   }
 
   .table tr:last-child td:first-child {
-    border-bottom-left-radius: 0px;
+    border-bottom-left-radius: 0;
   }
 
   .table tr:last-child td:last-child {
-    border-bottom-right-radius: 0px;
+    border-bottom-right-radius: 0;
   }
 }
 
@@ -140,16 +138,16 @@
    ========================================================================== */
 
 .light-loader {
-  position: absolute;
-  z-index: 97;
-  width: 100%;
   display: none;
   height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: 97;
 
   .spinner {
+    left: 50%;
     position: absolute;
     top: 50%;
-    left: 50%;
     transform: translateX(-50%) translateY(-50%);
   }
 }
@@ -163,14 +161,13 @@
 
 .empty-collection,
 .empty-data {
-  position: absolute;
-  z-index: 97;
-  width: 100%;
-  height: 100%;
+  animation: fadeIn .5s cubic-bezier(.3, 0, .3, 1) 0s 1 forwards;
   background: $white;
   display: none;
-
-  animation: fadeIn 0.5s cubic-bezier(0.3, 0, 0.3, 1) 0s 1 forwards;
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: 97;
 
   .notfound {
     position: relative;

--- a/packages/marble/src/_dropdowns.scss
+++ b/packages/marble/src/_dropdowns.scss
@@ -30,17 +30,17 @@
 
 .dropdown-menu li a,
 .dropdown-menu li button {
-  @include anim(color);
-  font-family: $font-primary;
-  font-weight: 600;
-  color: rgba($primary, 0.8);
-  font-size: 12px;
-
+  color: rgba($primary, .8);
   display: block;
+  font-family: $font-primary;
+  font-size: 12px;
+  font-weight: 600;
   padding: 10px 40px;
   text-decoration: none;
-  width: 100%;
   white-space: nowrap;
+  width: 100%;
+
+  @include anim(color);
 
   &:hover,
   &:focus {
@@ -58,25 +58,25 @@
 
 .dropdown-icon .dropdown-menu li {
   &:first-child {
-    margin-top: 0px;
+    margin-top: 0;
   }
 
   &:last-child {
-    margin-bottom: 0px;
+    margin-bottom: 0;
   }
 }
 
 .dropdown-icon .dropdown-menu li a,
 .dropdown-icon .dropdown-menu li button {
-  @include anim(all);
   color: rgba($primary, .8);
   font-size: 12px;
+  line-height: 36px;
   margin: 0;
   padding: 0 20px;
-  line-height: 36px;
+
+  @include anim(all);
 
   span {
-    @include anim(color);
     color: rgba($primary, .8);
     display: inline-block;
     margin-right: 20px;
@@ -84,6 +84,8 @@
     text-align: center;
     top: 3px;
     width: 14px;
+
+    @include anim(color);
   }
 
   &:hover,
@@ -99,9 +101,9 @@
 
 .dropdown.dropdown-logs {
   .icon {
+    display: inline-block;
     line-height: 34px;
     margin-right: 20px;
-    display: inline-block;
     position: relative;
     top: 3px;
   }
@@ -109,14 +111,17 @@
   .icon-red {
     color: $color-red;
   }
+
   .icon-orange {
     color: $color-orange;
   }
+
   .icon-yellow {
     color: $color-yellow;
   }
+
   .icon-primary {
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
   }
 }
 
@@ -129,13 +134,13 @@
 
 .dropdown.dropdown-filter .btn.btn-default {
   border-radius: 4px;
+  font-family: $font-primary;
+  font-size: 14px;
+  font-weight: 700;
   height: 48px;
   line-height: 48px;
-  padding: 0 33px 0 12px;
   margin: 0;
-  font-size: 14px;
-  font-family: $font-primary;
-  font-weight: 700;
+  padding: 0 33px 0 12px;
   position: relative;
   text-align: left;
 }
@@ -147,11 +152,11 @@
 }
 
 .dropdown.dropdown-filter .dropdown-menu {
-  margin: 0px;
+  left: 0;
+  margin: 0;
+  min-width: 100%;
   padding: 12px 0;
   top: 100%;
-  left: 0;
-  min-width: 100%;
 }
 
 .dropdown.dropdown-filter .dropdown-menu li {
@@ -160,18 +165,18 @@
 }
 
 .dropdown.dropdown-filter .dropdown-menu li a {
-  border-bottom-width: 0px;
-  color: rgba($primary, 0.8);
+  border-bottom-width: 0;
+  color: rgba($primary, .8);
   font-family: $font-primary;
-  font-weight: 600;
   font-size: 12px;
-  padding: 0 20px;
+  font-weight: 600;
   line-height: 36px;
+  padding: 0 20px;
 }
 
 .dropdown.dropdown-filter .dropdown-menu li a:hover {
+  background-color: rgba($accent, .1);
   color: $accent;
-  background-color: rgba($accent, 0.1);
 }
 
 /* Dropdown Settings
@@ -184,20 +189,20 @@
 }
 
 .dropdown.dropdown-settings .btn-icon {
-  display: block;
   border-radius: 4px;
-  margin: 0;
+  display: block;
   line-height: 48px;
+  margin: 0;
   padding: 0 12px;
   width: 46px;
 }
 
 .dropdown.dropdown-settings .dropdown-menu {
-  right: 20px;
   left: auto;
-  margin: 0;
   list-style: none;
+  margin: 0;
   padding: 12px 0;
+  right: 20px;
 }
 
 .dropdown.dropdown-settings .dropdown-menu li {
@@ -205,33 +210,31 @@
 }
 
 .dropdown.dropdown-settings .dropdown-menu li a {
-  border-bottom-width: 0px;
-  color: rgba(14, 20, 26, 0.8);
+  border-bottom-width: 0;
+  color: rgba(14, 20, 26, .8);
   font-family: $font-primary;
-  font-weight: 600;
   font-size: 12px;
+  font-weight: 600;
+  line-height: 36px;
   margin: 0;
   padding: 0 20px;
-  line-height: 36px;
-
-  transition: all 0.3s ease-in-out;
+  transition: all .3s ease-in-out;
 }
 
 .dropdown.dropdown-settings .dropdown-menu li a:hover {
+  background-color: rgba($accent, .1);
   color: $accent;
-  background-color: rgba($accent, 0.1);
 }
 
 .dropdown.dropdown-settings .dropdown-menu li a span {
-  color: rgba(14, 20, 26, 0.8);
+  color: rgba(14, 20, 26, .8);
   display: inline-block;
   margin-right: 20px;
   position: relative;
   text-align: center;
   top: 3px;
+  transition: color .3s ease-in-out;
   width: 14px;
-
-  transition: color 0.3s ease-in-out;
 }
 
 .dropdown.dropdown-settings .dropdown-menu li a:hover span {
@@ -247,39 +250,39 @@
 }
 
 .dropdown.dropdown-confirmation .dropdown-menu {
-  width: 218px;
   left: 50%;
-  transform: translateX(-50%);
-  top: 100%;
-  margin: 0;
   list-style: none;
+  margin: 0;
   padding: 12px;
   text-align: center;
+  top: 100%;
+  transform: translateX(-50%);
+  width: 218px;
 }
 
 .dropdown.dropdown-confirmation .dropdown-menu h3 {
-  color: rgba($primary, 0.8);
-  font-size: 14px;
+  color: rgba($primary, .8);
   font-family: $font-primary;
+  font-size: 14px;
   font-weight: 700;
 }
 
 .dropdown.dropdown-confirmation .dropdown-menu p {
-  color: rgba($primary, 0.4);
-  font-size: 11px;
+  color: rgba($primary, .4);
   font-family: $font-secondary;
+  font-size: 11px;
   font-weight: 600;
 }
 
 .dropdown.dropdown-confirmation .dropdown-menu .btn {
-  width: calc(50% - 6px);
-  height: 36px;
-  margin-right: 12px;
-  font-size: 12px;
   font-family: $font-primary;
+  font-size: 12px;
   font-weight: 600;
+  height: 36px;
   line-height: 36px;
+  margin-right: 12px;
   padding: 0;
+  width: calc(50% - 6px);
 }
 
 .dropdown.dropdown-confirmation .dropdown-menu .btn:last-child {

--- a/packages/marble/src/_forms.scss
+++ b/packages/marble/src/_forms.scss
@@ -5,14 +5,13 @@
    ========================================================================== */
 
 label {
+  color: rgba($primary, .6);
   font-family: $font-secondary;
-  font-weight: 600;
-  color: rgba($primary, 0.6);
   font-size: 12px;
+  font-weight: 600;
+  line-height: 24px;
   margin-bottom: 0;
   margin-left: 2px;
-  line-height: 24px;
-
   position: relative;
   top: -4px;
 }
@@ -27,18 +26,17 @@ label {
 }
 
 .form-control {
-  @include anim(background);
   background: rgba($primary, .05);
   border: 0;
   box-shadow: none;
   color: rgba($primary, .8);
+  font-family: $font-primary;
   font-size: 16px;
+  font-size: 14px;
+  font-weight: 600;
   padding: 0 20px;
 
-  font-family: $font-primary;
-  font-weight: 600;
-  font-size: 14px;
-  color: rgba($primary, 0.8);
+  @include anim(background);
 
   &:focus {
     background: rgba($primary, .1);
@@ -50,7 +48,6 @@ label {
     background: rgba($primary, .2);
     color: rgba($primary, .6);
   }
-
 }
 
 .has-action-button {
@@ -75,22 +72,21 @@ label {
 
   .btn-primary {
     background-color: rgba($primary, .1);
-    color: rgba($primary, .6);
-    width: 36px;
-    height: 36px;
     border-radius: 4px;
-    position: absolute;
-    padding: 0;
+    color: rgba($primary, .6);
+    height: 36px;
     overflow: hidden;
-    top: 12px;
+    padding: 0;
+    position: absolute;
     right: 12px;
-
+    top: 12px;
+    width: 36px;
 
     [classˆ="icon-12-"], [class*="icon-12-"] {
-      line-height: 36px;
-      width: 36px;
-      text-align: center;
       display: block;
+      line-height: 36px;
+      text-align: center;
+      width: 36px;
     }
 
     &:hover,
@@ -112,31 +108,32 @@ label {
 
     &:hover {
       overflow: visible;
+
       .btn-tooltip {
         opacity: 1;
       }
     }
 
     .btn-tooltip {
-      @include anim(opacity);
+      background: $white;
+      border-radius: 4px;
+      box-shadow: 0 10px 20px rgba($primary, .1);
+      color: rgba($primary, 8);
+      font-family: $font-secondary;
+      font-size: 12px;
+      font-weight: 600;
+      height: 36px;
+      left: 50%;
+      line-height: 36px;
       opacity: 0;
+      padding: 0 12px;
       position: absolute;
       top: calc(100% + 6px);
-      height: 36px;
-      border-radius: 4px;
-      padding: 0 12px;
-      left: 50%;
       transform: translateX(-50%);
-      background: $white;
-      font-family: $font-secondary;
-      font-weight: 600;
-      font-size: 12px;
-      color: rgba($primary, 8);
-      line-height: 36px;
-      box-shadow: 0 10px 20px rgba($primary, .1);
       z-index: 9999;
-    }
 
+      @include anim(opacity);
+    }
   }
 }
 
@@ -148,27 +145,26 @@ label {
 }
 
 .help-block {
-  font-family: $font-secondary;
-  font-weight: 600;
   color: rgba($secondary, .4);
+  font-family: $font-secondary;
   font-size: 12px;
+  font-weight: 600;
+  line-height: 24px;
   margin-bottom: 0;
   margin-left: 2px;
-  line-height: 24px;
-
-  transition: opacity 0.333s, visibility 0.333s, transform 0.333s;
-  visibility: hidden;
   opacity: 0;
   transform: translateY(-10%);
+  transition: opacity .333s, visibility .333s, transform .333s;
+  visibility: hidden;
 }
 
 .has-success,
 .has-warning,
 .has-error {
   .help-block {
-    visibility: visible;
     opacity: 1;
     transform: translateY(0);
+    visibility: visible;
   }
 }
 
@@ -215,6 +211,7 @@ label {
   background: $input-inverse-bg;
   border-color: $input-inverse-border;
   color: $input-inverse-color;
+
   @include placeholder($input-inverse-color-placeholder);
 
   &:focus {
@@ -223,10 +220,10 @@ label {
 }
 
 input[type="file"] {
-  padding: 22px 20px;
-  line-height: 10px;
-  font-size: 13px;
   font-family: $font-primary;
+  font-size: 13px;
   font-weight: 600;
+  line-height: 10px;
+  padding: 22px 20px;
   vertical-align: middle;
 }

--- a/packages/marble/src/_grid.scss
+++ b/packages/marble/src/_grid.scss
@@ -28,60 +28,55 @@
 }
 
 .container-hybrid-half {
-  width: calc(100% - 40px);
+  margin: 0 auto;
   max-width: 648px;
   padding: 0 20px;
-  margin: 0 auto;
+  width: calc(100% - 40px);
 }
 
 .container-hybrid-account {
-  width: calc(100% - 40px);
+  margin: 0 auto;
   max-width: 490px;
   padding: 0 20px;
-  margin: 0 auto;
+  width: calc(100% - 40px);
 }
 
 .col-flex-row-left-start {
-  display: flex;
-  justify-content: flex-start;
-  flex-direction: row;
   align-content: flex-start;
-  flex-wrap: nowrap;
   align-items: flex-start;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
 }
 
 .col-flex-row-left-center {
-  display: flex;
-  justify-content: flex-start;
-  flex-direction: row;
   align-content: center;
-  flex-wrap: nowrap;
   align-items: center;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
 }
 
 .col-flex-row-right-center {
-  display: flex;
-  justify-content: flex-end;
-  flex-direction: row;
   align-content: center;
-  flex-wrap: nowrap;
   align-items: center;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-end;
 }
 
 .col-flex-row-spacebetween-center {
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
   align-content: center;
-  flex-wrap: nowrap;
   align-items: center;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
 }
 
 .col-flex-row-spacebetween-start {
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
   align-content: flex-start;
-  flex-wrap: nowrap;
   align-items: flex-start;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
 }

--- a/packages/marble/src/_input-groups.scss
+++ b/packages/marble/src/_input-groups.scss
@@ -5,19 +5,17 @@
    ========================================================================== */
 
 .input-group-addon {
-  transition: color 0.333s, background 0.333s;
-
   background: rgba($primary, .2);
   border: 0;
   color: rgba($primary, .6);
   font-family: $font-primary;
-  font-weight: 600;
   font-size: 14px;
-
+  font-weight: 600;
   max-width: 200px;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: color .333s, background .333s;
+  white-space: nowrap;
 }
 
 .has-success {
@@ -53,9 +51,10 @@
 .input-inner-addon [class*="icon-12-"],
 .input-inner-addon [class^="icon-16-"],
 .input-inner-addon [class*="icon-16-"] {
-  @include anim(color);
   color: rgba($primary, .3);
   position: absolute;
+
+  @include anim(color);
 }
 
 .input-inner-addon-left [class^="icon-12-"],
@@ -120,18 +119,12 @@
 
 .input-btn-right,
 .input-group-addon-input-left {
-  border-bottom-left-radius: 4px !important;
-  border-top-left-radius: 4px !important;
-  border-bottom-right-radius: 0 !important;
-  border-top-right-radius: 0 !important;
+  border-radius: 4px 0 0 4px !important; /* stylelint-disable-line declaration-no-important */
 }
 
 .input-btn-left,
 .input-group-addon-input-right {
-  border-bottom-left-radius: 0 !important;
-  border-top-left-radius: 0 !important;
-  border-bottom-right-radius: 4px !important;
-  border-top-right-radius: 4px !important;
+  border-radius: 0 4px 4px 0 !important; /* stylelint-disable-line declaration-no-important */
 }
 
 .input-group-addon-input-center {
@@ -142,8 +135,8 @@
    ========================================================================== */
 
 .form-group .input-group .form-control.input-btn-separated {
-  width: calc(100% - 8px);
   border-radius: 4px;
+  width: calc(100% - 8px);
 }
 
 .input-group-btn.input-group-btn-separated:last-child > .btn {

--- a/packages/marble/src/_input-matrix.scss
+++ b/packages/marble/src/_input-matrix.scss
@@ -7,56 +7,57 @@
 }
 
 .form-group {
-  margin-bottom: 0px;
+  margin-bottom: 0;
+
   .help-block {
-    min-height: 24px;
-    padding: 0;
     color: $brand-danger;
     font-weight: 600;
     margin: 0 2px;
+    min-height: 24px;
+    padding: 0;
   }
 }
 
 .input-matrix .input-matrix-fields {
-  @extend .col-flex-row-left-start;
   position: relative;
+
+  @extend .col-flex-row-left-start;
 }
 
 .input-matrix .input-matrix-fields .input-matrix-fields-left {
-  position: relative;
-  left: 0;
-  width: 100%;
   flex-grow: 1;
+  left: 0;
+  position: relative;
+  width: 100%;
 }
 
 .input-matrix .input-matrix-fields .input-matrix-fields-right {
-  position: relative;
-  margin: 0 0 0 12px;
-  width: 60px;
-  height: 60px;
   flex-shrink: 0;
+  height: 60px;
+  margin: 0 0 0 12px;
+  position: relative;
+  width: 60px;
 
   .close {
-    transition: color 0.333s, background 0.333s;
-    text-align: center;
-    width: 20px;
+    background: rgba($primary, .05);
     border-radius: 4px;
+    color: rgba($primary, .4);
+    height: 60px;
     opacity: 1;
     outline: 0;
-
+    text-align: center;
+    transition: color .333s, background .333s;
+    width: 20px;
     width: 60px;
-    height: 60px;
-    background: rgba($primary, 0.05);
-    color: rgba($primary, 0.4);
 
     &:hover {
-      background: rgba($brand-danger, 0.1);
+      background: rgba($brand-danger, .1);
       color: $brand-danger;
     }
 
     > [class*="icon-16-"] {
+      left: .5px;
       position: relative;
-      left: 0.5px;
       top: 1.5px;
     }
   }
@@ -73,8 +74,8 @@
   }
 
   .input-matrix-label {
-    width: calc(50% - 8px);
     margin-right: 12px;
+    width: calc(50% - 8px);
 
     &:last-child {
       margin-right: 0;
@@ -95,23 +96,23 @@
   }
 
   .form-group {
-    width: 50%;
     margin-right: 12px;
+    width: 50%;
 
     &:last-child {
       margin-right: 0;
     }
 
     @media (max-width: $screen-md-min) {
-      width: 100%;
-      margin-right: 0;
       margin-bottom: 12px;
+      margin-right: 0;
+      width: 100%;
     }
   }
 }
 
 .input-matrix.input-matrix--inline .has-action-button {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 /* No Validation

--- a/packages/marble/src/_labels.scss
+++ b/packages/marble/src/_labels.scss
@@ -9,16 +9,16 @@
   border-radius: 4px;
   display: inline-block;
   font-family: $font-primary;
-  font-weight: 600;
   font-size: 14px;
+  font-weight: 600;
+  line-height: 36px;
   padding: 0 12px;
   position: relative;
-  line-height: 36px;
 
   &.label-sm {
-    padding: 0 12px;
     font-size: 12px;
     line-height: 24px;
+    padding: 0 12px;
   }
 }
 
@@ -71,10 +71,10 @@
    ========================================================================== */
 
 .label .label-icon {
+  color: inherit;
   margin-right: 6px;
   position: relative;
   top: 2px;
-  color: inherit;
 }
 
 /* Clickable
@@ -86,22 +86,25 @@
   position: relative;
 
   .label-action {
-    @include anim(top, 0.2s);
     left: 50%;
     position: absolute;
     top: -100%;
     transform: translateX(-50%);
+
+    @include anim(top, .2s);
   }
 
   .label-icon {
-    @include anim(top, 0.2s);
     position: relative;
+
+    @include anim(top, .2s);
   }
 
   .label-content {
-    @include anim(top, 0.2s);
     position: relative;
     top: 0;
+
+    @include anim(top, .2s);
   }
 
   &:hover {

--- a/packages/marble/src/_lists.scss
+++ b/packages/marble/src/_lists.scss
@@ -3,12 +3,13 @@
    ========================================================================== */
 
 .list .listitem {
-  @include anim(background);
   border: none;
   list-style: none;
   margin: 0;
   padding: 35px 12px;
   width: 100%;
+
+  @include anim(background);
 }
 
 .list .listitem:last-child {
@@ -21,8 +22,8 @@
 
 .list .list-text-primary {
   color: rgba($primary, .8);
-  font-size: 18px;
   font-family: $font-primary;
+  font-size: 18px;
   font-weight: 400;
   line-height: 24px;
   position: relative;
@@ -31,16 +32,16 @@
 
 .list .list-text-secondary {
   color: rgba($primary, .4);
-  font-size: 14px;
   font-family: $font-secondary;
+  font-size: 14px;
   line-height: 24px;
   position: relative;
   top: 4px;
 }
 
 .list .list-label {
-  margin-top: 6px;
   margin-left: 10px;
+  margin-top: 6px;
 }
 
 .list .btn-icon {
@@ -59,8 +60,8 @@
 }
 
 .list .avatar-photo img {
-  width: 48px;
   height: 48px;
+  width: 48px;
 }
 
 /* List v2.0
@@ -68,14 +69,15 @@
 
 .list {
   list-style: none;
-  width: 100%;
-  padding: 0;
   margin: 0;
+  padding: 0;
+  width: 100%;
 }
 
 .list.list--inline {
+  display: flex !important; /* stylelint-disable-line declaration-no-important */
+
   @extends .flex-container--row-left-center;
-  display: flex !important;
 }
 
 .list.list--inline .list__item {
@@ -89,29 +91,28 @@
 }
 
 .list.list--numeric {
+  color: rgba($primary, .8);
   margin: 0;
   padding: 0 0 0 40px;
-  color: rgba($primary, .8);
 }
+
 .list.list--numeric li {
+  counter-increment: list;
   font-family: $font-secondary;
   font-size: 16px;
   line-height: 24px;
+  list-style-type: none;
   margin: 0 0 0 40px;
   padding: 0;
-  list-style-type: none;
-  counter-increment: list;
   position: relative;
 }
 
-.list.list--numeric li:after {
-  content: counter(list) ".";
-  position: absolute;
-  top: 0;
-  left: -68px;
-  width: 40px;
-  text-align: right;
+.list.list--numeric li::after {
   color: rgba($primary, .4);
+  content: counter(list) ".";
+  left: -68px;
+  position: absolute;
+  text-align: right;
+  top: 0;
+  width: 40px;
 }
-
-

--- a/packages/marble/src/_mixins.scss
+++ b/packages/marble/src/_mixins.scss
@@ -12,8 +12,4 @@
   &::selection {
     background: rgba($primary, .1);
   }
-
-  &::-moz-selection {
-    background: rgba($primary, .1);
-  }
 }

--- a/packages/marble/src/_modals.scss
+++ b/packages/marble/src/_modals.scss
@@ -10,15 +10,15 @@
   outline: none;
   position: absolute;
   top: 50%;
-  width: 582px;
   transform: translate(-50%, -50%);
+  width: 582px;
 }
 
 .modal-content {
   background-clip: initial;
   border: 0;
-  box-shadow: none;
   border-radius: $border-radius-base;
+  box-shadow: none;
 }
 
 /* Modal - Header
@@ -32,22 +32,23 @@
 .modal-header .modal-title {
   color: rgba($primary, .8);
   font-family: $font-primary;
-  font-weight: 600;
   font-size: 28px;
+  font-weight: 600;
   line-height: 24px;
-  margin: 49px 0 0 0;
+  margin: 49px 0 0;
   text-transform: capitalize;
 }
 
 .modal-header .close {
-  @include anim(all);
   color: rgba($primary, .4);
   cursor: pointer;
   float: right;
   font-size: 32px;
   line-height: 16px;
-  outline: none;
   opacity: 1;
+  outline: none;
+
+  @include anim(all);
 }
 
 .modal-header .close:hover {
@@ -59,8 +60,8 @@
    ========================================================================== */
 
 .modal-body {
-  padding: 0 60px 60px;
   border: 0;
+  padding: 0 60px 60px;
 }
 
 .modal-body:empty {

--- a/packages/marble/src/_pill.scss
+++ b/packages/marble/src/_pill.scss
@@ -3,26 +3,23 @@
    ========================================================================== */
 
 .pill {
-  color: rgba($primary, 0.8);
-  background: rgba($primary, 0.05);
-  border-radius: 12px;
-
-  padding: 0 8px;
-  height: 24px;
-
-  display: inline-flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: center;
   align-content: center;
   align-items: center;
+  background: rgba($primary, .05);
+  border-radius: 12px;
+  color: rgba($primary, .8);
+  display: inline-flex;
+  flex-flow: row nowrap;
+  height: 24px;
+  justify-content: center;
+  padding: 0 8px;
 
   .pill-label {
+    display: inline-flex;
     font-family: $font-primary;
     font-size: 10px;
     font-weight: 700;
     line-height: 24px;
-    display: inline-flex;
     margin: 0;
   }
 
@@ -31,13 +28,13 @@
   }
 
   .pill-bullet {
-    background: rgba($primary, 0.4);
+    background: rgba($primary, .4);
     border-radius: 50%;
-    width: 8px;
-    height: 8px;
     flex: 0 0 auto;
+    height: 8px;
     margin: 0;
     padding: 0;
+    width: 8px;
 
     &.up {
       background: $accent;

--- a/packages/marble/src/_progress-bar.scss
+++ b/packages/marble/src/_progress-bar.scss
@@ -3,11 +3,11 @@
    ========================================================================== */
 
 .progress {
-  height: 8px;
   background: rgba($primary, .1);
   border-radius: 4px;
-  margin: 0 0 12px;
   box-shadow: none;
+  height: 8px;
+  margin: 0 0 12px;
   outline: 0;
 
   .progress-bar {

--- a/packages/marble/src/_radio.scss
+++ b/packages/marble/src/_radio.scss
@@ -3,17 +3,16 @@
    ========================================================================== */
 
 .radio-group {
-  list-style: none;
-  padding: 0;
-  margin-left: 0;
-
   font-family: $font-secondary;
-  font-weight: inherit;
   font-size: inherit;
+  font-weight: inherit;
+  list-style: none;
+  margin-left: 0;
+  padding: 0;
 
   > * {
-    line-height: 24px;
     display: block;
+    line-height: 24px;
   }
 
   &.radio-group-inline {
@@ -22,7 +21,7 @@
       margin-right: 24px;
 
       &:last-child {
-        margin-right: 0px;
+        margin-right: 0;
       }
     }
   }
@@ -34,13 +33,13 @@
 
 .radio-group * label {
   color: inherit;
+  cursor: pointer;
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
-  cursor: pointer;
-  padding-left: 24px;
   margin: 0;
+  padding-left: 24px;
   top: 0;
 }
 
@@ -48,20 +47,21 @@
   display: none;
 }
 
-.radio-group * input[type="radio"] + label:before {
-  @include anim(all);
-  color: rgba($primary, 0.8);
+.radio-group * input[type="radio"] + label::before {
+  color: rgba($primary, .8);
   content: "\E059";
-  font-family: 'icon-16';
+  font-family: "icon-16";
   font-size: 24px;
-  font-weight: normal;
+  font-weight: 400;
+  left: 0;
   line-height: 24px;
   position: absolute;
-  left: 0;
   top: 0;
+
+  @include anim(all);
 }
 
-.radio-group * input[type="radio"]:checked + label:before {
-  content: "\E058";
+.radio-group * input[type="radio"]:checked + label::before {
   color: $accent;
+  content: "\E058";
 }

--- a/packages/marble/src/_reading-progress.scss
+++ b/packages/marble/src/_reading-progress.scss
@@ -5,7 +5,7 @@
 .reading-progress {
   background: $white;
   border-radius: 4px;
-  box-shadow: 0 2px 8px rgba($primary, 0.1);
+  box-shadow: 0 2px 8px rgba($primary, .1);
   position: relative;
   width: 255px;
 }
@@ -21,8 +21,8 @@
 
 .reading-progress a {
   display: block;
-  position: relative;
   padding: 12px 12px 12px 60px;
+  position: relative;
 }
 
 .reading-progress a::before,
@@ -32,10 +32,10 @@
 
 .docs .reading-progress li a:not([class]),
 .docs .reading-progress p a:not([class]) {
-  border-bottom: 0px dashed rgba($primary, 0.4);
+  border-bottom: 0 dashed rgba($primary, .4);
 
   &:hover {
-    border-bottom: 0px dashed $accent;
+    border-bottom: 0 dashed $accent;
   }
 }
 
@@ -43,19 +43,19 @@
   background: transparent;
   border-radius: 50%;
   bottom: auto;
-  box-shadow: 0 2px 8px rgba($primary, 0.2);
+  box-shadow: 0 2px 8px rgba($primary, .2);
   color: rgba($primary, .4);
   content: counter(articles);
   font-family: $font-primary;
-  font-weight: 400;
   font-size: 12px;
+  font-weight: 400;
   height: 36px;
   left: 12px;
   line-height: 36px;
   text-align: center;
   top: 12px;
-  transition: background-color 0.3s, color 0.3s;
   transform: none;
+  transition: background-color .3s, color .3s;
   width: 36px;
 }
 
@@ -68,12 +68,12 @@
 }
 
 .reading-progress a.reading::before {
-  background-color: white;
+  background-color: $white;
   color: rgba($primary, .8);
 }
 
 .reading-progress a.read .reading-title {
-  color: rgba($primary, 0.6);
+  color: rgba($primary, .6);
   text-decoration: line-through;
 }
 
@@ -95,20 +95,20 @@
 }
 
 .reading-title {
-  color: rgba($primary, 0.6);
+  color: rgba($primary, .6);
   display: block;
   font-family: $font-primary;
-  font-weight: 400;
   font-size: 14px;
+  font-weight: 400;
   line-height: 24px;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: color 0.3s;
+  transition: color .3s;
   white-space: normal;
 }
 
 .reading-subtitle {
-  color: rgba($primary, 0.4);
+  color: rgba($primary, .4);
   font-size: 10px;
 }
 

--- a/packages/marble/src/_ribbon.scss
+++ b/packages/marble/src/_ribbon.scss
@@ -3,28 +3,28 @@
    ========================================================================== */
 
 .ribbon-container {
-  width: 85px;
   height: 88px;
   overflow: hidden;
   position: absolute;
-  top: -5px;
   right: -4px;
+  top: -5px;
+  width: 85px;
 }
 
 .ribbon {
-  font-family: $font-primary;
-  font-weight: 600;
-  text-align: center;
-  transform: rotate(45deg);
-  position: relative;
-  padding: 7px 0;
-  left: -5px;
-  top: 15px;
-  width: 120px;
+  background-color: rgba($primary, .8);
+  box-shadow: 0 0 3px rgba($primary, .3);
   color: $white;
-  background-color: rgba($primary, 0.8);
-  box-shadow: 0px 0px 3px rgba($primary, 0.3);
+  font-family: $font-primary;
   font-size: 14px;
+  font-weight: 600;
+  left: -5px;
+  padding: 7px 0;
+  position: relative;
+  text-align: center;
+  top: 15px;
+  transform: rotate(45deg);
+  width: 120px;
 }
 
 .ribbon.ribbon-accent {
@@ -43,19 +43,19 @@
   background-color: $brand-danger;
 }
 
-.ribbon:before, .ribbon:after {
-  content: "";
-  border-top:   3px solid rgba($primary, 0.6);
-  border-left:  3px solid transparent;
+.ribbon::before, .ribbon::after {
+  border-left: 3px solid transparent;
   border-right: 3px solid transparent;
-  position:absolute;
+  border-top: 3px solid rgba($primary, .6);
   bottom: -3px;
+  content: "";
+  position: absolute;
 }
 
-.ribbon:before {
+.ribbon::before {
   left: 0;
 }
 
-.ribbon:after {
+.ribbon::after {
   right: 0;
 }

--- a/packages/marble/src/_scaffolding.scss
+++ b/packages/marble/src/_scaffolding.scss
@@ -5,23 +5,25 @@
    ========================================================================== */
 
 body {
-  text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+  letter-spacing: -.02rem;
+  text-rendering: optimizeLegibility;
   text-size-adjust: 100%;
-  letter-spacing: -0.02rem;
 }
 
 body.fade-out {
-  @include anim(opacity);
   display: block;
   opacity: 0;
   overflow: hidden;
+
+  @include anim(opacity);
 }
 
 body.fade-in {
-  @include anim(opacity);
   opacity: 1;
+
+  @include anim(opacity);
 }
 
 .primary-bg {

--- a/packages/marble/src/_select.scss
+++ b/packages/marble/src/_select.scss
@@ -7,8 +7,8 @@
 }
 
 .select .dropdown .btn {
-  background: rgba($primary, 0.05);
-  color: rgba($primary, 0.6);
+  background: rgba($primary, .05);
+  color: rgba($primary, .6);
   font-size: 14px;
   font-weight: 400;
   padding: 0 18px 0 20px;
@@ -17,34 +17,33 @@
 }
 
 .select .dropdown .btn img {
-  margin: 18px 18px 0 0;
-  width: 24px;
-  height: 24px;
   border-radius: 4px;
   float: left;
+  height: 24px;
+  margin: 18px 18px 0 0;
+  width: 24px;
 }
 
 .select .dropdown .btn [class^="icon-12-"],
 .select .dropdown .btn [class*="icon-12-"] {
-  position: absolute;
   line-height: 58px;
+  position: absolute;
   right: 20px;
-  top: 0px;
+  top: 0;
 }
 
-
 .select .dropdown .icon-16-arrow-down-short {
-  position: absolute;
+  color: rgba($primary, .4);
   line-height: 58px;
+  position: absolute;
   right: 12px;
   top: 1px;
-  color: rgba($primary, 0.4);
 }
 
 .select .dropdown .dropdown-menu {
   margin: -60px 0 0;
-  width: 100%;
   padding: 12px 0;
+  width: 100%;
 }
 
 .select .dropdown .dropdown-menu li {
@@ -53,29 +52,29 @@
 }
 
 .select .dropdown .dropdown-menu li a {
-  border-bottom-width: 0px;
-  line-height: 24px;
-  height: 36px;
-  padding: 6px 20px;
-  color: rgba($primary, 0.8);
+  border-bottom-width: 0;
+  color: rgba($primary, .8);
   font-family: $font-primary;
-  font-weight: 600;
   font-size: 14px;
+  font-weight: 600;
+  height: 36px;
+  line-height: 24px;
   margin: 0;
+  padding: 6px 20px;
 }
 
 .select .dropdown .dropdown-menu li a img {
-  width: 24px;
-  height: 24px;
   border-radius: 4px;
-  margin: 0 18px 0 0;
   float: left;
-}
-.select .dropdown .dropdown-menu li a:hover {
-  color: rgba($primary, 0.8);
-  background-color: rgba($accent, 0.1);
+  height: 24px;
+  margin: 0 18px 0 0;
+  width: 24px;
 }
 
+.select .dropdown .dropdown-menu li a:hover {
+  background-color: rgba($accent, .1);
+  color: rgba($primary, .8);
+}
 
 /* ==========================================================================
    Select Large
@@ -86,77 +85,77 @@
 }
 
 .select.select-large .dropdown .btn {
+  background: rgba($primary, .05);
+  color: rgba($primary, .8);
   font-family: $font-primary;
-  font-weight: 600;
   font-size: 14px;
-  color: rgba($primary, 0.8);
-  background: rgba($primary, 0.05);
+  font-weight: 600;
 }
 
 .select.select-large .dropdown .btn:hover,
 .select.select-large .dropdown .btn:focus {
-  background: rgba($primary, 0.1);
+  background: rgba($primary, .1);
 }
 
 .select.select-large .dropdown .btn img {
-  margin: 12px 18px 0 0;
-  width: 36px;
-  height: 36px;
-  border-radius: 4px;
-  margin-right: 20px;
-  box-shadow: 0 2px 8px rgba($primary, 0.1);
   background: $white;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba($primary, .1);
+  height: 36px;
+  margin: 12px 18px 0 0;
+  margin-right: 20px;
+  width: 36px;
 }
 
 .select.select-large .dropdown .btn .none {
+  color: rgba($primary, .2);
   text-transform: lowercase;
-  color: rgba($primary, 0.2);
 }
 
 .select.select-large .dropdown .btn .none .avatar {
-  width: 36px;
+  background: $white;
+  color: rgba($primary, .2);
+  float: left;
   height: 36px;
   margin-right: 20px;
-  color: rgba($primary, 0.2);
-  float: left;
   margin-top: 12px;
-  background: $white;
+  width: 36px;
 }
 
 .select.select-large .dropdown .btn .none .avatar [class^="icon-16-"],
 .select.select-large .dropdown .btn .none .avatar [class*="icon-16-"] {
-  line-height: 36px;
-  vertical-align: middle;
-  text-align: center;
   display: block;
-  top: 0;
+  line-height: 36px;
   margin: 0;
+  text-align: center;
+  top: 0;
+  vertical-align: middle;
 }
 
 .select.select-large .dropdown .dropdown-menu li a {
-  height: 60px;
-  padding: 12px 20px;
-  cursor: pointer;
-  color: rgba($primary, 0.8);
-  line-height: 36px;
   background: $white;
+  color: rgba($primary, .8);
+  cursor: pointer;
+  height: 60px;
+  line-height: 36px;
+  padding: 12px 20px;
 }
 
 .select.select-large .dropdown .dropdown-menu li a img {
   border-radius: 4px;
+  box-shadow: 0 2px 8px rgba($primary, .1);
+  height: 36px;
   margin-right: 20px;
   width: 36px;
-  height: 36px;
-  box-shadow: 0 2px 8px rgba($primary, 0.1);
 }
 
 .select.select-large .dropdown .dropdown-menu li a .none .avatar {
-  width: 36px;
-  height: 36px;
-  float: left;
-  margin-right: 20px;
-  color: rgba($primary, 0.5);
   background: $white;
+  color: rgba($primary, .5);
+  float: left;
+  height: 36px;
+  margin-right: 20px;
+  width: 36px;
 }
 
 .select.select-large .dropdown .dropdown-menu li a .none .avatar span {

--- a/packages/marble/src/_sidebars.scss
+++ b/packages/marble/src/_sidebars.scss
@@ -6,8 +6,8 @@
    ========================================================================== */
 
 .sidebar {
-  background: white;
-  box-shadow: 0 2px 8px rgba($primary, 0.1);
+  background: $white;
+  box-shadow: 0 2px 8px rgba($primary, .1);
   height: auto;
   left: 0;
   padding: 0;
@@ -33,12 +33,11 @@
   }
 
   .container-hybrid .flex-row {
-    display: flex;
-    justify-content: flex-start;
-    flex-direction: row;
     align-content: center;
-    flex-wrap: wrap;
     align-items: center;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: flex-start;
 
     > * {
       float: none;
@@ -48,17 +47,18 @@
 
 /* Sidebar > list
    ========================================================================== */
+
 .sidebar-list {
+  height: 100%;
   list-style: none;
   margin: 0;
-  padding: 0;
-
-  height: 100%;
   overflow-y: auto;
+  padding: 0;
 }
 
 /* Sidebar > list > header
    ========================================================================== */
+
 .sidebar-list-header {
   margin: 24px 12px;
 
@@ -68,16 +68,15 @@
 
   .sidebar-list-header-title {
     color: rgba($primary, .8);
-    font-size: 17px;
     font-family: $font-primary;
+    font-size: 17px;
     font-weight: 700;
     line-height: 24px;
-    padding: 0;
     margin: 0;
+    padding: 0;
   }
 
   .sidebar-list-header-subtitle {
-    @include anim(color);
     color: rgba($primary, .8);
     display: block;
     font-family: $font-secondary;
@@ -85,7 +84,9 @@
     line-height: 24px;
     margin: 0;
     padding: 0;
-    position:relative;
+    position: relative;
+
+    @include anim(color);
 
     &:hover {
       color: $accent;
@@ -95,6 +96,7 @@
 
 /* Sidebar > list > item
    ========================================================================== */
+
 .sidebar-item {
   display: block;
 
@@ -105,30 +107,30 @@
 
 /* Sidebar > Header
    ========================================================================== */
+
 .sidebar-header {
-  @include anim(background);
-  background: rgba($primary, 0.05);
-  color: rgba($primary, 0.8);
+  align-content: center;
+  align-items: center;
+  background: rgba($primary, .05);
+  color: rgba($primary, .8);
   cursor: pointer;
   display: block;
+  display: flex;
+  flex-flow: row nowrap;
   font-size: 14px;
   font-weight: 600;
+  justify-content: flex-start;
   line-height: 24px;
   padding: 18px 12px;
   user-select: none;
   width: 100%;
 
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: flex-start;
-  align-content: center;
-  align-items: center;
+  @include anim(background);
 }
 
 .sidebar-header:hover,
 .sidebar-header:focus {
-  background: rgba($primary, 0.1);
+  background: rgba($primary, .1);
 }
 
 .sidebar-header span {
@@ -153,11 +155,21 @@
 /* Sidebar > Toggle Header
    ========================================================================== */
 
-.toggler-header-collapsed .icon-12-arrow-up-short   { display: none; }
-.toggler-header-collapsed .icon-12-arrow-down-short { display: inline; }
+.toggler-header-collapsed .icon-12-arrow-up-short {
+  display: none;
+}
 
-.toggler-header-expanded .icon-12-arrow-up-short   { display: inline; }
-.toggler-header-expanded .icon-12-arrow-down-short { display: none; }
+.toggler-header-collapsed .icon-12-arrow-down-short {
+  display: inline;
+}
+
+.toggler-header-expanded .icon-12-arrow-up-short {
+  display: inline;
+}
+
+.toggler-header-expanded .icon-12-arrow-down-short {
+  display: none;
+}
 
 .toggler-collapsed {
   display: none;
@@ -171,23 +183,25 @@
 }
 
 .sidebar-search .form-control {
-  @include anim(all);
   background: rgba($primary, .05);
-  border-color: white;
+  border-color: $white;
   color: rgba($primary, .4);
   font-family: $font-primary;
   font-weight: 600;
+
+  @include anim(all);
 }
 
 .sidebar-search .input-inner-icon-helper {
-  @include anim(color);
   color: rgba($primary, .6);
   line-height: 24px;
   top: 20px;
+
+  @include anim(color);
 }
 
 .sidebar-search .form-control:focus {
-  background: white;
+  background: $white;
   border-color: $accent;
   color: rgba($primary, .8);
 }
@@ -204,29 +218,29 @@
 }
 
 .sidebar-list .sidebar-link {
-  @include anim(all);
-
   border-radius: 0;
-  color: rgba($primary, 0.8);
-  line-height: 24px;
-  font-family: $font-primary;
-  font-weight: 700;
-  font-size: 13px;
-  padding: 12px;
+  color: rgba($primary, .8);
   display: block;
+  font-family: $font-primary;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 24px;
+  padding: 12px;
   text-decoration: none;
+
+  @include anim(all);
 }
 
 .sidebar-list .sidebar-settings-item .sidebar-link {
   img {
-    width: 24px;
     height: 24px;
     margin-right: 8px;
+    width: 24px;
   }
 
   span:not(.sidebar-icon) {
-    line-height: 24px;
     display: inline-block;
+    line-height: 24px;
     position: relative;
     top: 1px;
   }
@@ -270,7 +284,6 @@
   .sidebar-search .form-group {
     margin: 0 0 24px;
   }
-
 }
 
 /* Sidebar Offset => Large screens
@@ -281,8 +294,8 @@
     .container,
     .container-hybrid {
       max-width: $screen-lg-min - $sidebar-width;
-      padding-left: 0px;
-      padding-right: 0px;
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 }
@@ -292,8 +305,8 @@
     .container,
     .container-hybrid {
       max-width: 948px;
-      padding-left: 0px;
-      padding-right: 0px;
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 }
@@ -303,8 +316,8 @@
     .container,
     .container-hybrid {
       max-width: calc(1440px - #{$sidebar-width});
-      padding-left: 0px;
-      padding-right: 0px;
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 }
@@ -314,23 +327,24 @@
     .container,
     .container-hybrid {
       max-width: $screen-lg-min;
-      padding-left: 0px;
-      padding-right: 0px;
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 }
 
 /* Sidebar Navigation Menu
    ========================================================================== */
+
 .sidebar-navigation {
+  display: none;
+  height: 100vh;
+  left: 0;
   position: fixed;
   top: 0;
-  left: 0;
-  height: 100vh;
   width: 100vw;
   z-index: 9999;
 
-  display: none;
   @media (min-width: 960px) {
     display: inline-block;
     width: 252px;
@@ -342,14 +356,14 @@
   }
 
   .sidebar-navigation-fade {
-    background: rgba($primary, 0.3);
-    width: 100%;
+    animation: fadeIn .3s cubic-bezier(.3, 0, .3, 1) .1s 1 forwards;
+    background: rgba($primary, .3);
+    cursor: pointer;
+    display: inline-block;
     height: 100%;
     opacity: 0;
-    animation: fadeIn 0.3s cubic-bezier(0.3, 0, 0.3, 1) 0.1s 1 forwards;
-    cursor: pointer;
+    width: 100%;
 
-    display: inline-block;
     @media (min-width: 960px) {
       display: none;
     }
@@ -357,8 +371,9 @@
 }
 
 .sidebar-navigation.open {
-  width: 100vw;
   display: inline-block;
+  width: 100vw;
+
   @media (min-width: 960px) {
     display: inline-block;
     width: 252px;
@@ -366,7 +381,7 @@
 }
 
 .sidebar-navigation.open .sidebar {
+  animation: fadeInToRight .3s cubic-bezier(.3, 0, .3, 1) .1s 1 forwards;
   opacity: 0;
   position: absolute;
-  animation: fadeInToRight 0.3s cubic-bezier(0.3, 0, 0.3, 1) 0.1s 1 forwards;
 }

--- a/packages/marble/src/_slider.scss
+++ b/packages/marble/src/_slider.scss
@@ -3,28 +3,28 @@
    ========================================================================== */
 
 .slider {
+  cursor: pointer;
   position: relative;
   text-align: center;
-  cursor: pointer;
 
   span {
     display: none;
   }
 
   .rail {
+    background: rgba($primary, .1);
     border-radius: 4px;
     height: 8px;
     position: relative;
     z-index: 1;
-    background: rgba($primary, 0.1)
   }
 
   .rail-handle {
-    position: absolute;
-    z-index: 10;
-    top: -5px;
     height: 18px;
+    position: absolute;
+    top: -5px;
     width: 18px;
+    z-index: 10;
   }
 
   .rail-active {
@@ -37,10 +37,9 @@
   .handle {
     background-color: $white;
     border-radius: 50%;
-    margin: 0 -9px;
+    box-shadow: 0 2px 12px rgba($primary, .12);
     height: 18px;
+    margin: 0 -9px;
     width: 18px;
-    box-shadow: 0 2px 12px rgba($primary, 0.12);
   }
-
 }

--- a/packages/marble/src/_spinner.scss
+++ b/packages/marble/src/_spinner.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .spinner {
-  color: white;
+  color: $white;
   display: inline-block;
   font-family: "icon-12";
   font-size: 12px;
@@ -16,26 +16,27 @@
 }
 
 .spinner.spinner-small {
-  line-height: 18px;
   height: 24px;
+  line-height: 18px;
   width: 24px;
-  &:before {
+
+  &::before {
     font-size: 12px;
     height: 24px;
-    width: 24px;
     margin-left: -12px;
     padding-left: 1px;
+    width: 24px;
   }
 }
 
-.spinner.spinner-small:not(:required):before {
+.spinner.spinner-small:not(:required)::before {
   border: 3px solid $white;
   border-bottom-color: $brand-success;
   border-left-color: $brand-success;
   border-top-color: $brand-success;
 }
 
-.alert-dark .spinner.spinner-small:not(:required):before {
+.alert-dark .spinner.spinner-small:not(:required)::before {
   border: 3px solid transparent;
   border-bottom-color: $brand-success;
   border-left-color: $brand-success;
@@ -43,26 +44,27 @@
 }
 
 .spinner.spinner-medium {
-  line-height: 26px;
   height: 36px;
+  line-height: 26px;
   width: 36px;
-  &:before {
+
+  &::before {
     font-size: 16px;
     height: 36px;
-    width: 36px;
     margin-left: -18px;
     padding-left: 2px;
+    width: 36px;
   }
 }
 
-.spinner.spinner-medium:not(:required):before {
+.spinner.spinner-medium:not(:required)::before {
   border: 4px solid $white;
   border-bottom-color: $brand-success;
   border-left-color: $brand-success;
   border-top-color: $brand-success;
 }
 
-.alert-dark .spinner.spinner-medium:not(:required):before {
+.alert-dark .spinner.spinner-medium:not(:required)::before {
   border: 4px solid transparent;
   border-bottom-color: $brand-success;
   border-left-color: $brand-success;
@@ -70,81 +72,82 @@
 }
 
 .spinner.spinner-large {
-  line-height: 34px;
   height: 48px;
+  line-height: 34px;
   width: 48px;
-  &:before {
+
+  &::before {
     font-size: 24px;
     height: 48px;
-    width: 48px;
     margin-left: -24px;
     padding-left: 2px;
+    width: 48px;
   }
 }
 
-.spinner.spinner-large:not(:required):before {
+.spinner.spinner-large:not(:required)::before {
   border: 5px solid $white;
   border-bottom-color: $brand-success;
   border-left-color: $brand-success;
   border-top-color: $brand-success;
 }
 
-.alert-dark .spinner.spinner-large:not(:required):before {
+.alert-dark .spinner.spinner-large:not(:required)::before {
   border: 5px solid transparent;
   border-bottom-color: $brand-success;
   border-left-color: $brand-success;
   border-top-color: $brand-success;
 }
 
-.spinner:before {
+.spinner::before {
   height: 24px;
+  margin-left: -12px;
   position: absolute;
   width: 24px;
-  margin-left: -12px;
 }
 
-.spinner:not(:required):before {
-  content: "";
-  border-radius: 50%;
+.spinner:not(:required)::before {
+  animation: rotate-360 .6s linear infinite;
   border: 3px solid $white;
   border-bottom-color: $brand-success;
   border-left-color: $brand-success;
+  border-radius: 50%;
   border-top-color: $brand-success;
-  animation: rotate-360 .6s linear infinite;
+  content: "";
 }
 
-.alert-dark .spinner:not(:required):before {
+.alert-dark .spinner:not(:required)::before {
   border: 3px solid transparent;
   border-bottom-color: $brand-success;
   border-left-color: $brand-success;
   border-top-color: $brand-success;
 }
 
-.spinner-done:not(:required):before {
-  content: "\E018";
+.spinner-done:not(:required)::before {
+  animation: none;
   background: $brand-success;
   border-color: $brand-success;
-  animation: none;
+  content: "\E018";
 }
 
-.spinner.spinner-danger:not(:required):before {
+.spinner.spinner-danger:not(:required)::before {
   border-bottom-color: $brand-danger;
   border-left-color: $brand-danger;
   border-top-color: $brand-danger;
 }
 
-.spinner.spinner-danger.spinner-done:not(:required):before {
+.spinner.spinner-danger.spinner-done:not(:required)::before {
   background: $brand-danger;
   border-color: $brand-danger;
 }
 
-.spinner.spinner-warning:not(:required):before {
+.spinner.spinner-warning:not(:required)::before {
   border-bottom-color: $brand-warning;
   border-left-color: $brand-warning;
   border-top-color: $brand-warning;
 }
 
-.spinner.spinner-warning.spinner-done:not(:required):before {
+.spinner.spinner-warning.spinner-done:not(:required)::before {
   background: $brand-warning;
   border-color: $brand-warning;
 }
@@ -170,18 +173,18 @@
   margin-left: 8px;
 }
 
-.label .spinner:not(:required):before {
-  top: 0px;
-  font-size: 16px;
-  font-family: 'icon-16';
-  line-height: 24px;
-  content: "\E061";
-  background: rgba($white, 0);
-  border: 0px solid $white;
-  width: 24px;
-  height: 24px;
-  padding: 0;
+.label .spinner:not(:required)::before {
   animation: rotate-360 1s linear infinite;
+  background: rgba($white, 0);
+  border: 0 solid $white;
+  content: "\E061";
+  font-family: "icon-16";
+  font-size: 16px;
+  height: 24px;
+  line-height: 24px;
+  padding: 0;
+  top: 0;
+  width: 24px;
 }
 
 .label .spinner,

--- a/packages/marble/src/_switchers.scss
+++ b/packages/marble/src/_switchers.scss
@@ -3,50 +3,50 @@
    ========================================================================== */
 
 .switcher {
-  transition: background 0.333s;
-  background: rgba($primary, 0.02);
+  background: rgba($primary, .02);
+  border: 1px solid rgba($primary, .12);
   border-radius: 18px;
-  border: 1px solid rgba($primary, 0.12);
   cursor: pointer;
   height: 36px;
   outline: none;
-  width: 60px;
   position: relative;
+  transition: background .333s;
+  width: 60px;
 
-  &:before:not(.disabled) {
-    content: " ";
-    border-radius: 18px;
-    transition: background 0.333s;
+  &::before:not(.disabled) {
     background: transparent;
-    position: absolute;
-    width: 100%;
+    border-radius: 18px;
+    content: " ";
     height: 100%;
+    position: absolute;
+    transition: background .333s;
+    width: 100%;
   }
 
-  &:hover:before:not(.disabled) {
-    background: rgba($primary, 0.05);
+  &:hover::before:not(.disabled) {
+    background: rgba($primary, .05);
   }
 
   &.disabled {
     cursor: not-allowed;
-    opacity: 0.6;
+    opacity: .6;
   }
 }
 
 .switcher-control {
-  position: absolute;
-  transition: left 0.333s;
   background: $white;
   border-radius: 50%;
-  box-shadow: 0 1px 4px rgba($primary, 0.1), 0 2px 4px rgba($primary, 0.05), 0 2px 8px rgba($primary, 0.1);
+  box-shadow: 0 1px 4px rgba($primary, .1), 0 2px 4px rgba($primary, .05), 0 2px 8px rgba($primary, .1);
+  height: 28px;
   left: 0;
   margin: 3px 3px 0;
-  height: 28px;
   outline: none;
+  position: absolute;
+  transition: left .333s;
   width: 28px;
 
   &:hover {
-    box-shadow: 0 1px 4px rgba($primary, 0.15), 0 2px 4px rgba($primary, 0.1), 0 2px 8px rgba($primary, 0.15);
+    box-shadow: 0 1px 4px rgba($primary, .15), 0 2px 4px rgba($primary, .1), 0 2px 8px rgba($primary, .15);
   }
 }
 
@@ -61,7 +61,8 @@
   border-radius: 24px;
   height: 48px;
   width: 72px;
-  &:before {
+
+  &::before {
     border-radius: 24px;
   }
 }
@@ -79,7 +80,8 @@
   border-radius: 12px;
   height: 24px;
   width: 42px;
-  &:before {
+
+  &::before {
     border-radius: 12px;
   }
 }
@@ -137,5 +139,5 @@
 }
 
 .switcher-on.primary {
-  background: rgba($primary, 0.8);
+  background: rgba($primary, .8);
 }

--- a/packages/marble/src/_tables.scss
+++ b/packages/marble/src/_tables.scss
@@ -10,29 +10,30 @@ table {
   width: 100%;
 
   * {
-    border-width: 0px !important;
+    border-width: 0 !important; /* stylelint-disable-line declaration-no-important */
   }
 }
 
 table thead tr {
-  background: rgba($primary, 0.05);
+  background: rgba($primary, .05);
 }
 
 table tbody tr {
   &:nth-child(odd) {
-    background: rgba($primary, 0.02);
+    background: rgba($primary, .02);
   }
+
   &:nth-child(even) {
-    background: rgba($primary, 0.05);
+    background: rgba($primary, .05);
   }
 }
 
 table tr th,
 table tr td {
-  border-width: 0px;
+  border-width: 0;
   font-size: $font-small;
-  line-height: calc(1rem * #{$lineHeight});
-  padding: calc(0.5rem * #{$lineHeight}) calc(1rem * #{$lineHeight});
-  vertical-align: top;
   height: calc(2rem * #{$lineHeight});
+  line-height: calc(1rem * #{$lineHeight});
+  padding: calc(.5rem * #{$lineHeight}) calc(1rem * #{$lineHeight});
+  vertical-align: top;
 }

--- a/packages/marble/src/_tooltip.scss
+++ b/packages/marble/src/_tooltip.scss
@@ -9,19 +9,17 @@
 }
 
 .tooltip-inner {
-  width: 100%;
+  background: $white;
+  border-radius: $border-radius-base;
+  box-shadow: 0 2px 8px rgba($black, .1);
+  color: rgba($primary, .8);
+  font-family: $font-primary;
+  font-size: 12px;
+  font-weight: 700;
   max-width: 220px;
   padding: 12px;
-
-  background: white;
-  border-radius: $border-radius-base;
-  box-shadow: 0 2px 8px rgba(black, .1);
-
-  color: rgba($primary, 0.8);
-  font-size: 12px;
-  font-family: $font-primary;
-  font-weight: 700;
   text-align: center;
+  width: 100%;
 }
 
 .text-left .tooltip-inner {
@@ -41,93 +39,88 @@
 
 .tooltip.tooltip-dark,
 .tooltip.tooltip-light {
+  margin: 0;
+  opacity: 0;
+  padding: 0;
   position: fixed;
-  padding: 0px;
-  margin: 0px;
+  transform: translateY(-6px);
 
   /* Animations
      ======================================================================== */
-
-  transition: opacity 0.333s, transform 0.333s, visibility 0.333s;
-  transform: translateY(-6px);
+  transition: opacity .333s, transform .333s, visibility .333s;
   visibility: hidden;
-  opacity: 0;
 
   &.showing {
-    transform: translateY(0px);
-    visibility: visible;
     opacity: 1;
+    transform: translateY(0);
+    visibility: visible;
     will-change: opacity;
   }
 }
 
 .tooltip.tooltip-dark .tooltip-inner,
 .tooltip.tooltip-light .tooltip-inner {
+  background: $white;
+  border-radius: $border-radius-large;
+  box-shadow: $shadow-tooltip;
+  color: rgba($primary, .8);
   display: inline-block;
+  font-family: $font-primary;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 24px;
   margin: 12px;
   max-width: 300px;
   padding: 12px;
+  text-align: center;
   width: auto;
 
-  border-radius: $border-radius-large;
-  box-shadow: $shadow-tooltip;
-
-  background: $white;
-  color: rgba($primary, 0.8);
-  font-size: 13px;
-  font-family: $font-primary;
-  font-weight: 700;
-  line-height: 24px;
-  text-align: center;
-
   .tooltip-title {
-    position:relative;
-    z-index: 2;
-
     color: inherit;
-    font-size: inherit;
     font-family: inherit;
+    font-size: inherit;
     font-weight: inherit;
     line-height: inherit;
+    position: relative;
     text-align: inherit;
+    z-index: 2;
   }
 
   .tooltip-description {
-    position:relative;
-    z-index: 2;
-
     color: inherit;
-    font-size: 10px;
     font-family: $font-secondary;
+    font-size: 10px;
     font-weight: 400;
     line-height: inherit;
+    position: relative;
     text-align: inherit;
+    z-index: 2;
   }
 
   a {
-    @include anim(all);
+    border-bottom: 1px dashed rgba($primary, .8);
     color: inherit;
-    font-size: inherit;
     font-family: inherit;
+    font-size: inherit;
     font-weight: inherit;
     line-height: inherit;
     text-align: inherit;
-    border-bottom: 1px dashed rgba($primary, 0.8);
+
+    @include anim(all);
 
     &:hover {
-      color: $accent;
       border-bottom: 1px dashed $accent;
+      color: $accent;
     }
   }
 }
-
 
 /* Skin Dark
    ========================================================================== */
 
 .tooltip.tooltip-dark .tooltip-inner {
   background: $primary;
-  color: white;
+  color: $white;
 
   a {
     border-bottom: 1px dashed $white;

--- a/packages/marble/src/_topbars.scss
+++ b/packages/marble/src/_topbars.scss
@@ -116,7 +116,7 @@
   }
 
   &.toggler-header-expanded::after {
-    transform: scaleY(-1) translate3d(0,calc(50% - 2.5px),0);
+    transform: scaleY(-1) translate3d(0, calc(50% - 2.5px), 0);
   }
 }
 
@@ -127,11 +127,11 @@
 .topbar-list {
   background-color: $primary;
   color: $white;
-  overflow: hidden;
   left: 0;
   list-style-type: none;
   margin: 0;
   max-height: 0;
+  overflow: hidden;
   padding: 0;
   position: absolute;
   right: 0;
@@ -146,9 +146,9 @@
   @media (min-width: $screen-md-min) {
     background-color: transparent;
     color: inherit;
-    overflow: visible;
     left: auto;
     max-height: none;
+    overflow: visible;
     position: static;
     right: auto;
     top: auto;
@@ -202,9 +202,9 @@
   }
 
   & > span {
-    background-image: linear-gradient(currentColor 25%,transparent 50%);
-    background-repeat: no-repeat;
+    background-image: linear-gradient(currentColor 25%, transparent 50%);
     background-position: calc(200% - 2px) 100%;
+    background-repeat: no-repeat;
     background-size: 200% 2px;
     margin-bottom: -3px;
     padding-bottom: 3px;

--- a/packages/marble/src/_variables.scss
+++ b/packages/marble/src/_variables.scss
@@ -9,9 +9,9 @@ $primary   : #0e141a !default;
 $secondary : $primary !default;
 $accent    : #00d46a !default;
 
-$black      : #000 !default;
-$white      : #fff !default;
-$gray-light : #888 !default;
+$black      : #000000 !default;
+$white      : #ffffff !default;
+$gray-light : #888888 !default;
 
 $brand-primary : $primary !default;
 $brand-success : #00d46a !default;
@@ -92,7 +92,7 @@ $btn-primary-border: transparent !default;
 $btn-success-border: transparent !default;
 $btn-danger-border: transparent !default;
 
-$btn-accent-color: white !default;
+$btn-accent-color: $white !default;
 $btn-accent-bg: $accent !default;
 $btn-accent-border: transparent !default;
 
@@ -114,7 +114,7 @@ $input-color: $primary !default;
 $input-color-placeholder: rgba($primary, .3) !default;
 $input-group-addon-bg: transparent !default;
 $input-height-base: 60px !default;
-$input-bg-disabled: white !default;
+$input-bg-disabled: $white !default;
 
 $input-inverse-bg: rgba($primary, .05) !default;
 $input-inverse-border-focus: $white !default;
@@ -137,7 +137,7 @@ $border-radius-large: 4px !default;
 /* Dropdowns
    ========================================================================== */
 
-$dropdown-border: rgba($primary, 0.12) !default;
+$dropdown-border: rgba($primary, .12) !default;
 $dropdown-link-color: rgba($primary, .5) !default;
 $dropdown-link-hover-color: rgba($primary, .9) !default;
 $dropdown-link-hover-bg: none !default;
@@ -145,9 +145,9 @@ $dropdown-link-hover-bg: none !default;
 /* Bonus
    ========================================================================== */
 
-$shadow-small: 0 1px 1px rgba($primary, 0.08) !default;
-$shadow-large: 0 2px 4px rgba($primary, 0.12) !default;
-$shadow-tooltip: 0 6px 12px rgba($primary, 0.1) !default;
+$shadow-small: 0 1px 1px rgba($primary, .08) !default;
+$shadow-large: 0 2px 4px rgba($primary, .12) !default;
+$shadow-tooltip: 0 6px 12px rgba($primary, .1) !default;
 
 $transition-duration: .3s !default;
 $transition-function: ease-in-out !default;

--- a/packages/marble/src/_wedeploy-logo.scss
+++ b/packages/marble/src/_wedeploy-logo.scss
@@ -7,76 +7,76 @@
     z-index: 999;
 
     .version-container {
-      position: absolute;
-      left: 48px;
       bottom: 6px;
-      width: 48px;
       height: 24px;
+      left: 48px;
+      position: absolute;
+      width: 48px;
 
       .version {
-        bottom: 0;
-        width: 48px;
-        height: 25px;
         background: $white;
-        color: rgba($primary, 0.8);
+        bottom: 0;
+        color: rgba($primary, .8);
+        height: 25px;
+        width: 48px;
       }
 
       .arrow-left {
-        top: 6px;
-        border-top: 6px solid transparent !important;
-        border-bottom: 6px solid transparent !important;
+        border-bottom: 6px solid transparent !important; /* stylelint-disable-line declaration-no-important */
         border-right: 6px solid $white;
+        border-top: 6px solid transparent !important; /* stylelint-disable-line declaration-no-important */
+        top: 6px;
       }
     }
   }
 
   .docs-nav-container {
-    position: relative;
     display: none;
+    position: relative;
   }
 
   .we-circle {
+    background: $accent;
+    border-radius: 50%;
+    display: inline-block;
     height: 36px;
     width: 36px;
-    background: $accent;
-    display: inline-block;
-    border-radius: 50%;
   }
 
   .we {
-    height: 36px;
-    width: 36px;
-    line-height: 36.6px;
-    color: $white;
-    font-size: 15px;
-    font-family: $font-primary;
-    font-weight: 700;
-    border-radius: 50%;
-    display: inline-block;
-    text-align: center;
     background: none;
+    border-radius: 50%;
+    color: $white;
+    display: inline-block;
+    font-family: $font-primary;
+    font-size: 15px;
+    font-weight: 700;
+    height: 36px;
+    line-height: 36.6px;
+    text-align: center;
+    width: 36px;
   }
 
   .deploy {
-    font-size: 17px;
-    line-height: 36px;
-    font-family: $font-primary;
-    font-weight: 700;
     color: rgba($white, .9);
+    font-family: $font-primary;
+    font-size: 17px;
+    font-weight: 700;
+    line-height: 36px;
     margin-left: 6px;
   }
 
   .liferay {
     color: rgba($white, .3);
     font-family: $font-primary;
-    font-weight: 400;
     font-size: 10px;
+    font-weight: 400;
     margin-left: 4px;
   }
 
   .version-container {
-    position: absolute;
     bottom: -7px;
+    position: absolute;
     width: 48px;
     z-index: 999;
 
@@ -84,46 +84,42 @@
       display: none;
     }
 
-    @media(min-width: 960px) {
+    @media (min-width: 960px) {
       display: block;
     }
 
     .version {
-      position: absolute;
-      bottom: -30px;
-      width: 48px;
-      height: 24px;
+      background: rgba($primary, .05);
       border-radius: 4px;
-      text-align: center;
-      line-height: 24px;
-      background: rgba($primary, 0.05);
+      bottom: -30px;
+      color: rgba($primary, .4);
       display: block;
-      color: rgba($primary, 0.4);
       font-size: 11px;
+      height: 24px;
+      line-height: 24px;
+      position: absolute;
+      text-align: center;
+      width: 48px;
     }
 
     .arrow-up {
-      width: 0;
-      height: 0;
+      border-bottom: 6px solid rgba($primary, .05);
       border-left: 6px solid transparent;
       border-right: 6px solid transparent;
-
-      border-bottom: 6px solid rgba($primary, 0.05);
-
-      position: absolute;
+      height: 0;
       left: 20px;
+      position: absolute;
+      width: 0;
     }
 
     .arrow-left {
-      width: 0;
-      height: 0;
-      border-top: 6px solid transparent;
       border-bottom: 6px solid transparent;
-
-      border-right: 6px solid rgba($primary, 0.05);
-
-      position: absolute;
+      border-right: 6px solid rgba($primary, .05);
+      border-top: 6px solid transparent;
+      height: 0;
       left: -6px;
+      position: absolute;
+      width: 0;
     }
   }
 }
@@ -140,60 +136,60 @@
   }
 
   .we {
-    height: 48px;
-    width: 48px;
-    line-height: 48px;
-    font-size: 22px;
     background: none;
+    font-size: 22px;
+    height: 48px;
+    left: .5px;
+    line-height: 48px;
     position: relative;
-    top: 0.5px;
-    left: 0.5px
+    top: .5px;
+    width: 48px;
   }
 
   .deploy {
     font-size: 22px;
     line-height: 48px;
-    position: relative;
     margin-left: 3px;
+    position: relative;
     top: 1px;
   }
 
   .liferay {
     font-size: 11px;
+    left: -2px;
+    letter-spacing: .003em;
     position: relative;
     top: 1px;
-    letter-spacing: 0.003em;
-    left: -2px;
   }
-
 }
 
 .topbar.topbar-light .wedeploy-logo {
   .deploy {
     color: rgba($primary, .9);
   }
+
   .liferay {
     color: rgba($primary, .3);
   }
 
   &.dashboard-logo {
     .version {
-      background: rgba($primary, 0.05);
+      background: rgba($primary, .05);
     }
 
     .arrow-up {
-      border-bottom: 6px solid rgba($primary, 0.05);
+      border-bottom: 6px solid rgba($primary, .05);
     }
 
     .arrow-left {
-      border-right: 6px solid rgba($primary, 0.05);
+      border-right: 6px solid rgba($primary, .05);
     }
   }
 }
 
 .topbar.topbar-inverse {
   .we {
-    color: $accent;
     background: $white;
+    color: $accent;
   }
 }

--- a/packages/marble/src/marble.scss
+++ b/packages/marble/src/marble.scss
@@ -95,7 +95,7 @@
 @import "senna";
 
 .truncate {
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/packages/marble/src/templates/api/_api.scss
+++ b/packages/marble/src/templates/api/_api.scss
@@ -28,7 +28,7 @@
 .api .card {
   background: $white;
   border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(14, 20, 26, 0.1);
+  box-shadow: 0 2px 8px rgba(14, 20, 26, .1);
   position: relative;
 }
 

--- a/packages/marble/src/templates/blog/_blog.scss
+++ b/packages/marble/src/templates/blog/_blog.scss
@@ -18,7 +18,7 @@
   padding: 0 24px;
   margin: 0;
 
-  li:before {
+  li::before {
     content: "";
   }
 }
@@ -49,7 +49,7 @@
 
   .container .content a {
     @include anim(color);
-    border-bottom: 1px dashed rgba($primary, 0.4);
+    border-bottom: 1px dashed rgba($primary, .4);
     color: inherit;
 
     &:hover,
@@ -60,7 +60,7 @@
   }
 
   .posts-list {
-    background: rgba($primary, 0.02);
+    background: rgba($primary, .02);
     padding: calc(3rem * #{$lineHeight}) 0;
   }
 
@@ -81,7 +81,7 @@
   }
 
   .posts-list a:hover small {
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
   }
 
   .posts-list a h4 {
@@ -203,7 +203,7 @@
     width: calc(2rem * #{$lineHeight});
     height: calc(2rem * #{$lineHeight});
     border-radius: 50%;
-    background: rgba($primary, 0.1);
+    background: rgba($primary, .1);
     display: inline-block;
   }
 
@@ -216,7 +216,7 @@
     width: 2rem;
     text-align: center;
     position: relative;
-    top: 0.5px;
-    left: 0.5px;
+    top: .5px;
+    left: .5px;
   }
 }

--- a/packages/marble/src/templates/docs/_action-button.scss
+++ b/packages/marble/src/templates/docs/_action-button.scss
@@ -17,7 +17,7 @@
 }
 
 .guide-aux-cta {
-  color: rgba($primary, 0.6);
+  color: rgba($primary, .6);
   font-family: $font-secondary;
   font-weight: 600;
   font-size: 13px;

--- a/packages/marble/src/templates/docs/_contribute.scss
+++ b/packages/marble/src/templates/docs/_contribute.scss
@@ -49,7 +49,7 @@
   color: inherit;
   font-family: inherit;
   font-size: inherit;
-  border-bottom: 1px dashed rgba($primary, 0.4);
+  border-bottom: 1px dashed rgba($primary, .4);
 
   &:hover {
     color: $accent;

--- a/packages/marble/src/templates/docs/_guide.scss
+++ b/packages/marble/src/templates/docs/_guide.scss
@@ -29,7 +29,7 @@
 .docs .guide-content {
 
   h1, h2, h3, h4, h5, h6 {
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
     display: block;
     font-family: $font-primary;
     font-weight: 700;
@@ -74,7 +74,7 @@
   }
 
   h6 {
-    color: rgba($primary, 0.6);
+    color: rgba($primary, .6);
     font-weight: 600;
     font-size: $font-h6;
     line-height: calc(1rem * #{$lineHeight});
@@ -86,7 +86,7 @@
     font-weight: 400;
     font-size: $font-p;
     line-height: calc(1rem * #{$lineHeight});
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
   }
 
   p:not([class]) {
@@ -107,11 +107,11 @@
     font-weight: 600;
     font-size: $font-small;
     line-height: calc(1rem * #{$lineHeight});
-    color: rgba($primary, 0.4);
+    color: rgba($primary, .4);
     margin-bottom: calc(1rem * #{$lineHeight});
 
     .guide-info-separator {
-      color: rgba($primary, 0.6);
+      color: rgba($primary, .6);
     }
   }
 
@@ -135,7 +135,7 @@
     position: relative;
   }
 
-  ul:not([class]) li:before {
+  ul:not([class]) li::before {
     font-family: $font-primary;
     font-weight: 700;
     display: inline-block;
@@ -151,7 +151,7 @@
     margin-left: 0;
   }
 
-  ul.checklist li:before {
+  ul.checklist li::before {
     color: $accent;
     content: "\E017";
     display: inline-block;
@@ -168,7 +168,7 @@
     position: relative;
   }
 
-  ol li:before {
+  ol li::before {
     font-family: $font-primary;
     font-weight: 700;
     color: inherit;
@@ -188,13 +188,13 @@
     @include anim(color);
     font-family: inherit;
     font-size: inherit;
-    border-bottom: 1px dashed rgba($primary, 0.4);
+    border-bottom: 1px dashed rgba($primary, .4);
     color: inherit;
 
     &:hover,
     &:focus {
       border-color: $accent;
-      color: rgba($accent, 0.6);
+      color: rgba($accent, .6);
     }
   }
 
@@ -202,7 +202,7 @@
   /* ======================================================================== */
 
   code {
-    background: rgba($primary, 0.1);
+    background: rgba($primary, .1);
     display: inline-block;
     font-family: $font-mono;
     font-size: $font-small;
@@ -244,7 +244,7 @@
     font-weight: 700;
     font-size: $font-h4;
     line-height: calc(2rem * #{$lineHeight});
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
     border: 0px;
     padding: 0;
   }
@@ -255,7 +255,7 @@
 
   blockquote::before {
     content: '\201C';
-    color: rgba($primary, 0.4);
+    color: rgba($primary, .4);
     display: block;
     width: 2.5rem;
     text-align: left;
@@ -264,7 +264,7 @@
   blockquote::after {
     position: relative;
     content: '\201D';
-    color: rgba($primary, 0.4);
+    color: rgba($primary, .4);
     display: block;
     width: 2.5rem;
     text-align: left;
@@ -277,16 +277,16 @@
   figure {
     width: 100%;
     text-align: center;
-    padding: calc(0.5rem * #{$lineHeight}) 0;
+    padding: calc(.5rem * #{$lineHeight}) 0;
 
     figcaption {
-      color: rgba($primary, 0.4);
+      color: rgba($primary, .4);
       font-family: $font-secondary;
       font-weight: 400;
       font-size: $font-small;
       line-height: calc(1rem * #{$lineHeight});
       text-align: center;
-      margin-top: 0.5rem;
+      margin-top: .5rem;
     }
   }
 
@@ -317,7 +317,7 @@
 
   aside {
     padding: calc(1rem * #{$lineHeight});
-    background: rgba($primary, 0.05);
+    background: rgba($primary, .05);
     border-radius: 4px;
     margin-bottom: calc(1rem * #{$lineHeight});
 
@@ -333,7 +333,7 @@
     p,
     li,
     li label {
-      font-size: 0.8125rem;
+      font-size: .8125rem;
 
       code {
         display: inline;

--- a/packages/marble/src/templates/docs/_header.scss
+++ b/packages/marble/src/templates/docs/_header.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .docs header {
-  background: rgba($primary, 0.02);
+  background: rgba($primary, .02);
   text-align: center;
   padding: 60px 0;
   margin-top: 0;

--- a/packages/marble/src/templates/docs/_nav-group.scss
+++ b/packages/marble/src/templates/docs/_nav-group.scss
@@ -30,7 +30,7 @@
 
 .docs-nav-link {
   @include anim(color);
-  color: rgba($primary, 0.6);
+  color: rgba($primary, .6);
   font-size: 14px;
 }
 

--- a/packages/marble/src/templates/docs/_reading-progress.scss
+++ b/packages/marble/src/templates/docs/_reading-progress.scss
@@ -14,7 +14,7 @@
 .docs .docs-nav {
   width: auto;
   opacity: 0;
-  animation: fadeIn 0.5s cubic-bezier(0.3, 0, 0.3, 1) 0s 1 forwards;
+  animation: fadeIn .5s cubic-bezier(.3, 0, .3, 1) 0s 1 forwards;
 }
 
 .docs-nav.affix {

--- a/packages/marble/src/templates/docs/_sidebar.scss
+++ b/packages/marble/src/templates/docs/_sidebar.scss
@@ -41,11 +41,11 @@
    ========================================================================== */
 
 .docs .sidebar-header {
-  background: rgba($primary, 0.03);
-  color: rgba($primary, 0.8);
+  background: rgba($primary, .03);
+  color: rgba($primary, .8);
 
   .sidebar-icon {
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
   }
 }
 
@@ -68,7 +68,7 @@
    ========================================================================== */
 
 .docs .sidebar-list .sidebar-link {
-  color: rgba(14, 20, 26, 0.8);
+  color: rgba(14, 20, 26, .8);
   font-size: 13px;
   font-weight: 600;
   height: auto;
@@ -99,7 +99,7 @@
    ========================================================================== */
 .docs .sidebar-list .sidebar-icon {
   @include anim(color);
-  color: rgba(14, 20, 26, 0.6);
+  color: rgba(14, 20, 26, .6);
   display: inline-block;
   margin-right: 12px;
   margin-top: -1px;

--- a/packages/marble/src/templates/docs/_topbar.scss
+++ b/packages/marble/src/templates/docs/_topbar.scss
@@ -4,7 +4,7 @@
 
 .guide:not(.content) {
   .topbar {
-    background: rgba($primary, 0.02);
+    background: rgba($primary, .02);
   }
 
   .topbar-list {

--- a/packages/marble/src/templates/docs/_topic.scss
+++ b/packages/marble/src/templates/docs/_topic.scss
@@ -13,7 +13,7 @@
   text-align: center;
 
   .topic-icon,
-  &.radial-out:before {
+  &.radial-out::before {
     background: $accent;
   }
 }
@@ -105,7 +105,7 @@
   transform: translateZ(0);
 }
 
-.radial-out:before {
+.radial-out::before {
   content: "";
   position: absolute;
   z-index: -1;
@@ -115,17 +115,17 @@
   bottom: 0;
   border-radius: 100%;
   transform: scale(0);
-  transition: transform 0.4s ease-out;
+  transition: transform .4s ease-out;
 }
 
-.radial-out:hover:before,
-.radial-out:focus:before {
+.radial-out:hover::before,
+.radial-out:focus::before {
   transform: scale(2);
 }
 
 .radial-out .topic-icon {
   transform: scale(1);
-  transition: transform 0.4s ease-out;
+  transition: transform .4s ease-out;
 }
 
 .radial-out:hover .topic-icon,
@@ -136,7 +136,7 @@
 .radial-out .topic-title {
   top: 0;
   position: relative;
-  transition: all 0.4s ease-out;
+  transition: all .4s ease-out;
 }
 
 .radial-out:hover .topic-title,

--- a/packages/marble/src/templates/root/_code.scss
+++ b/packages/marble/src/templates/root/_code.scss
@@ -4,8 +4,8 @@
 
 * code {
   display: inline-block;
-  color: rgba($primary, 0.6);
-  background: rgba($primary, 0.1);
+  color: rgba($primary, .6);
+  background: rgba($primary, .1);
   font-size: 100%;
   font-family: $font-mono;
   padding: 0 4px;
@@ -28,7 +28,7 @@ h6 code {
 
 p a:not([class]),
 li a:not([class]) {
-  border-bottom: 1px dashed rgba($primary, 0.4);
+  border-bottom: 1px dashed rgba($primary, .4);
   color: inherit;
 
   &:hover {
@@ -48,7 +48,7 @@ li a:not([class]) {
 .nav.nav-tabs.nav-code-tabs > li > button {
   background: transparent;
   border-width: 0px;
-  color: rgba($primary, 0.8);
+  color: rgba($primary, .8);
   font-family: $font-primary;
   font-size: 13px;
   font-weight: 700;
@@ -60,7 +60,7 @@ li a:not([class]) {
   &:hover,
   &:focus {
     background: transparent;
-    color: rgba($primary, 0.6);
+    color: rgba($primary, .6);
     outline: none;
   }
 }
@@ -95,7 +95,7 @@ li a:not([class]) {
 }
 
 .code-container .CodeMirror {
-  animation: fadeIn 0.5s cubic-bezier(0.3, 0, 0.3, 1) 0s 1 forwards;
+  animation: fadeIn .5s cubic-bezier(.3, 0, .3, 1) 0s 1 forwards;
   border-radius: 0px;
   height: auto;
   opacity: 0;
@@ -186,7 +186,7 @@ li a:not([class]) {
   width: 36px;
   z-index: 999;
 
-  &:before {
+  &::before {
     @include anim(background);
     content: "";
     position: absolute;
@@ -195,15 +195,15 @@ li a:not([class]) {
     width: 36px;
     height: 36px;
     border-radius: 4px;
-    background: rgba($white, 0.2);
+    background: rgba($white, .2);
     z-index: 1;
   }
 
   &:hover {
     background: $primary;
 
-    &:before {
-      background: rgba($white, 0.4);
+    &::before {
+      background: rgba($white, .4);
     }
   }
 
@@ -225,7 +225,7 @@ li a:not([class]) {
   }
 
   ::-webkit-scrollbar-thumb {
-    transition: all 0.3s ease-in-out;
+    transition: all .3s ease-in-out;
     border-radius: 12px;
   }
 }
@@ -234,7 +234,7 @@ li a:not([class]) {
   @include scrollbar();
 
   ::-webkit-scrollbar-track {
-    background-color: rgba($primary, 0.8);
+    background-color: rgba($primary, .8);
   }
 
   ::-webkit-scrollbar-track:vertical {
@@ -252,12 +252,12 @@ li a:not([class]) {
   }
 
   ::-webkit-scrollbar-thumb {
-    background-color: rgba($white, 0.4);
+    background-color: rgba($white, .4);
     border: 4px solid $color-charade;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background-color: rgba($white, 0.6);
+    background-color: rgba($white, .6);
   }
 
   ::-webkit-scrollbar-corner {

--- a/packages/marble/src/templates/root/_core.scss
+++ b/packages/marble/src/templates/root/_core.scss
@@ -20,8 +20,8 @@ $font-h4: 1rem * 2; // 2.125rem
 $font-h5: 1rem * $scaleFactor; // 1.5rem
 $font-h6: (1rem * pow($scaleFactor, 3)) / 4; // 1.0625rem
 $font-p: 1rem; // 1rem
-$font-small: (1rem * $scaleFactor) / 2; // 0.75rem
-$font-mini: 1rem / 2; // 0.5rem
+$font-small: (1rem * $scaleFactor) / 2; // .75rem
+$font-mini: 1rem / 2; // .5rem
 
 :root {
   font-size: 14px;

--- a/packages/marble/src/templates/root/_elements.scss
+++ b/packages/marble/src/templates/root/_elements.scss
@@ -24,7 +24,7 @@
   /* ======================================================================== */
 
   h1, h2, h3, h4, h5, h6 {
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
     display: block;
     font-family: $font-primary;
     font-weight: 700;
@@ -74,7 +74,7 @@
     font-weight: 400;
     font-size: $font-p;
     line-height: calc(1rem * #{$lineHeight});
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
   }
 
   small {
@@ -83,10 +83,10 @@
     font-weight: 600;
     font-size: $font-small;
     line-height: calc(1rem * #{$lineHeight});
-    color: rgba($primary, 0.4);
+    color: rgba($primary, .4);
     margin-bottom: calc(1rem * #{$lineHeight});
     span {
-      color: rgba($primary, 0.6);
+      color: rgba($primary, .6);
     }
   }
 
@@ -104,7 +104,7 @@
     position: relative;
   }
 
-  ul:not(.dropdown-menu):not(.radio-group):not(.checklist) > li:before {
+  ul:not(.dropdown-menu):not(.radio-group):not(.checklist) > li::before {
     font-family: $font-primary;
     font-weight: 700;
     display: inline-block;
@@ -125,7 +125,7 @@
     line-height: 24px;
   }
 
-  ul.checklist > li:before {
+  ul.checklist > li::before {
     color: $accent;
     content: "\E018";
     display: inline-block;
@@ -143,7 +143,7 @@
     position: relative;
   }
 
-  ol > li:before {
+  ol > li::before {
     font-family: $font-primary;
     font-weight: 700;
     color: inherit;
@@ -162,13 +162,13 @@
     @include anim(color);
     font-family: inherit;
     font-size: inherit;
-    border-bottom: 1px dashed rgba($primary, 0.4);
+    border-bottom: 1px dashed rgba($primary, .4);
     color: $accent;
 
     &:hover,
     &:focus {
       border-color: $accent;
-      color: rgba($accent, 0.6);
+      color: rgba($accent, .6);
     }
   }
 
@@ -176,7 +176,7 @@
   /* ======================================================================== */
 
   code {
-    background: rgba($primary, 0.1);
+    background: rgba($primary, .1);
     display: inline-block;
     font-family: $font-mono;
     font-size: $font-small;
@@ -217,7 +217,7 @@
     font-weight: 700;
     font-size: $font-h4;
     line-height: calc(2rem * #{$lineHeight});
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
     border: 0px;
     padding: 0;
   }
@@ -228,7 +228,7 @@
 
   blockquote::before {
     content: '\201C';
-    color: rgba($primary, 0.4);
+    color: rgba($primary, .4);
     display: block;
     width: 2.5rem;
     text-align: left;
@@ -237,7 +237,7 @@
   blockquote::after {
     position: relative;
     content: '\201D';
-    color: rgba($primary, 0.4);
+    color: rgba($primary, .4);
     display: block;
     width: 2.5rem;
     text-align: left;
@@ -250,7 +250,7 @@
   figure {
     width: 100%;
     text-align: center;
-    padding: calc(0.5rem * #{$lineHeight}) 0;
+    padding: calc(.5rem * #{$lineHeight}) 0;
 
     img {
       display: block;
@@ -271,13 +271,13 @@
     }
 
     figcaption {
-      color: rgba($primary, 0.4);
+      color: rgba($primary, .4);
       font-family: $font-secondary;
       font-weight: 400;
       font-size: $font-small;
       line-height: calc(1rem * #{$lineHeight});
       text-align: center;
-      margin-top: 0.5rem;
+      margin-top: .5rem;
     }
   }
 
@@ -299,7 +299,7 @@
   /* ======================================================================== */
 
   .card {
-    box-shadow: 0 2px 12px rgba($primary, 0.12);
+    box-shadow: 0 2px 12px rgba($primary, .12);
     border-radius: 4px;
     max-width: calc(34rem + 5rem);
     padding: calc(2rem * #{$lineHeight});
@@ -312,7 +312,7 @@
   aside,
   .aside {
     padding: calc(1rem * #{$lineHeight});
-    background: rgba($primary, 0.05);
+    background: rgba($primary, .05);
     border-radius: 4px;
 
     > * {
@@ -354,15 +354,15 @@
   }
 
   .content .table thead tr {
-    background: rgba($primary, 0.05);
+    background: rgba($primary, .05);
   }
 
   .content .table tbody tr {
     &:nth-child(odd) {
-      background: rgba($primary, 0.02);
+      background: rgba($primary, .02);
     }
     &:nth-child(even) {
-      background: rgba($primary, 0.05);
+      background: rgba($primary, .05);
     }
   }
 
@@ -371,7 +371,7 @@
     border-width: 0px;
     font-size: $font-small;
     line-height: calc(1rem * #{$lineHeight});
-    padding: calc(0.5rem * #{$lineHeight}) calc(1rem * #{$lineHeight});
+    padding: calc(.5rem * #{$lineHeight}) calc(1rem * #{$lineHeight});
     vertical-align: top;
     height: calc(2rem * #{$lineHeight});
   }
@@ -398,11 +398,11 @@
   }
 
   .content > .btn.btn-inverse-accent {
-    background: rgba($primary, 0.1);
-    color: rgba($primary, 0.8);
+    background: rgba($primary, .1);
+    color: rgba($primary, .8);
     &:focus,
     &:hover {
-      background: rgba($primary, 0.2);
+      background: rgba($primary, .2);
     }
   }
 

--- a/packages/marble/src/templates/tutorial/_tutorial-sidebar.scss
+++ b/packages/marble/src/templates/tutorial/_tutorial-sidebar.scss
@@ -7,8 +7,8 @@
   width: 100%;
 
   @media (min-width: 960px) {
-    margin-left: calc((0.5rem * #{$lineHeight}) * 21); // 252px;
-    width: calc(100% - ((0.5rem * #{$lineHeight}) * 21));
+    margin-left: calc((.5rem * #{$lineHeight}) * 21); // 252px;
+    width: calc(100% - ((.5rem * #{$lineHeight}) * 21));
   }
 }
 
@@ -16,11 +16,11 @@
   top: 0;
 
   @media (min-width: 960px) {
-    width: calc((0.5rem * #{$lineHeight}) * 21);
+    width: calc((.5rem * #{$lineHeight}) * 21);
   }
 
   .sidebar-list {
-    padding: calc(1rem * #{$lineHeight}) calc(0.5rem * #{$lineHeight});
+    padding: calc(1rem * #{$lineHeight}) calc(.5rem * #{$lineHeight});
   }
 
   .sidebar-item {
@@ -43,20 +43,20 @@
     align-items: center;
     border-radius: $border-radius-large;
 
-    padding: calc(0.5rem * #{$lineHeight});
+    padding: calc(.5rem * #{$lineHeight});
     width: 100%;
 
     font-family: $font-primary;
     font-weight: 600;
-    font-size: 0.8125rem;
-    color: rgba($primary, 0.8);
+    font-size: .8125rem;
+    color: rgba($primary, .8);
 
     &.sidebar-link-selected {
-      background: rgba($accent, 0.1);
+      background: rgba($accent, .1);
     }
 
     &.sidebar-link-read {
-      color: rgba($primary, 0.8);
+      color: rgba($primary, .8);
     }
 
     span:not(.tutorial-step) {
@@ -69,15 +69,15 @@
     font-family: $font-primary;
     font-weight: 600;
     display: block;
-    margin-right: calc(0.5rem * #{$lineHeight});
+    margin-right: calc(.5rem * #{$lineHeight});
     width: calc(1.5rem * #{$lineHeight});
     height: calc(1.5rem * #{$lineHeight});
     border-radius: 50%;
-    box-shadow: 0 2px 8px rgba($primary, 0.12);
+    box-shadow: 0 2px 8px rgba($primary, .12);
     text-align: center;
     line-height: calc(1.5rem * #{$lineHeight});
     background: white;
-    font-size: 0.8125rem;
+    font-size: .8125rem;
     flex-shrink: 0;
     position: relative;
     z-index: 1;
@@ -89,7 +89,7 @@
   }
 
   .sidebar-link .before {
-    background: rgba($primary, 0.1);
+    background: rgba($primary, .1);
     display: block;
     position: absolute;
     top: 0;
@@ -115,7 +115,7 @@
   }
 
   .sidebar-item .sidebar-link .after {
-    background: rgba($primary, 0.1);
+    background: rgba($primary, .1);
     top: 50%;
     display: block;
     height: 50%;
@@ -140,16 +140,16 @@
   }
 
   .sidebar-link .section-title {
-    font-size: 0.8125rem;
+    font-size: .8125rem;
   }
 
   .sidebar-link.sidebar-link-read .section-title {
-    color: rgba($primary, 0.6);
+    color: rgba($primary, .6);
     text-decoration: line-through;
   }
 
   .sidebar-link.sidebar-link-selected .tutorial-step {
     color: $accent;
-    box-shadow: 0 2px 8px rgba($accent, 0.1);
+    box-shadow: 0 2px 8px rgba($accent, .1);
   }
 }

--- a/packages/marble/src/templates/tutorial/_tutorial-topbar.scss
+++ b/packages/marble/src/templates/tutorial/_tutorial-topbar.scss
@@ -6,7 +6,7 @@
   width: 100%;
   height: calc(2.5rem * #{$lineHeight});
   min-height: 60px;
-  box-shadow: 0 2px 8px rgba($primary, 0.12);
+  box-shadow: 0 2px 8px rgba($primary, .12);
   padding: 0 12px;
   background: $accent;
 
@@ -65,14 +65,14 @@
 
     align-self: center;
 
-    font-size: 0.8125rem;
+    font-size: .8125rem;
     font-family: $font-primary;
     font-weight: 600;
-    color: rgba($white, 0.8);
+    color: rgba($white, .8);
     flex-shrink: 0;
 
     > * {
-      margin-right: calc(0.5rem * #{$lineHeight});
+      margin-right: calc(.5rem * #{$lineHeight});
 
       &:last-child {
         margin-right: 0;
@@ -89,6 +89,6 @@
   &.topbar--light .name ,
   &.topbar-light .time-remaining,
   &.topbar--light .time-remaining {
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
   }
 }

--- a/packages/marble/src/templates/tutorial/_tutorial.scss
+++ b/packages/marble/src/templates/tutorial/_tutorial.scss
@@ -36,8 +36,8 @@
   }
 
   .container a:not(.btn) {
-    transition: color 0.333s, border-bottom-width 0.333s;
-    color: rgba($primary, 0.8);
+    transition: color .333s, border-bottom-width .333s;
+    color: rgba($primary, .8);
     border-bottom-width: 1px;
   }
 
@@ -65,9 +65,9 @@
      ======================================================================== */
 
   .container .tutorial-time-remaining {
-    color: rgba($primary, 0.8);
+    color: rgba($primary, .8);
     font-family: $font-primary;
-    font-size: 0.8125rem;
+    font-size: .8125rem;
     font-weight: 600;
     margin-bottom: 20px;
 
@@ -76,7 +76,7 @@
     }
 
     .icon {
-      margin-right: calc(0.5rem * #{$lineHeight});
+      margin-right: calc(.5rem * #{$lineHeight});
       position: relative;
       top: 8px;
     }
@@ -90,7 +90,7 @@
     margin-top: 36px;
 
     .btn {
-      transition: background 0.333s;
+      transition: background .333s;
       margin: 0 6px 12px;
       font-size: 1rem;
 

--- a/packages/marble/src/templates/updates/_updates.scss
+++ b/packages/marble/src/templates/updates/_updates.scss
@@ -30,7 +30,7 @@
     }
   }
 
-  .update-timeline:before {
+  .update-timeline::before {
     background-color: $accent;
     bottom: 0;
     content: '';
@@ -42,7 +42,7 @@
   }
 
   .update-features {
-    border-bottom: 2px rgba(14, 20, 26, 0.1) solid;
+    border-bottom: 2px rgba(14, 20, 26, .1) solid;
     padding: 2em 0 3em 1em;
   }
 }
@@ -81,7 +81,7 @@
 
 .update-feature {
   .feature-icon {
-    color: rgba(14, 20, 26, 0.6);
+    color: rgba(14, 20, 26, .6);
     margin-right: 10px;
   }
 
@@ -120,7 +120,7 @@
       text-align: left;
     }
 
-    .update-timeline:before {
+    .update-timeline::before {
       display: none;
     }
   }


### PR DESCRIPTION
This changes several SCSS files to follow the conventions outlined in stylelint-config-dev (see: #31), with the exception of changing files to be indented with 2 spaces instead of tabs.

Major changes include:

1. Enforces alphabetical ordering of properties.
2. Enforces `$white` over `white`.
3. Enforces `.5px` over `0.5px`.
4. Enforces shorthand `flex-flow: X Y;` over `flow-direction: X; flex-wrap: Y;`.
5. Enforces a single space after a selector or property colon (`.some . selector {}`, `color: red`).
6. Enforces a trailing semicolon (`;`) after a declaration.
6. Enforces empty newlines between sibling rules.
7. Enforces double-quotes (`"`) for strings over single-quotes (`'`).
8. Enforces double-colon (`::`) for pseudo-elements (`::before`, `::after`).
9. Anything else changed by `stylelint --fix`.