### PR TITLE
Update topbar for docs

### DIFF
--- a/packages/marble/src/templates/docs/_topbar.scss
+++ b/packages/marble/src/templates/docs/_topbar.scss
@@ -5,6 +5,10 @@
 .guide:not(.content) {
   .topbar {
     background: rgba($primary, .02);
+
+    .topbar-canvas-expanded & {
+      background: $white;
+    }
   }
 
   .topbar-list {


### PR DESCRIPTION
The docs remove the background on topbars, so this change restores it when the canvas is expanded.