### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 coverage
 lib
 node_modules
+package-lock.json
 *.log


### PR DESCRIPTION
If this file should not be committed to the repository, then this file could be ignored by .gitignore?