### PR TITLE
Fixes link hover color in docs guide - Closes #556

### DIFF
--- a/packages/marble/src/templates/docs/_guide.scss
+++ b/packages/marble/src/templates/docs/_guide.scss
@@ -194,7 +194,7 @@
     &:hover,
     &:focus {
       border-color: $accent;
-      color: rgba($accent, .6);
+      color: $accent;
     }
   }
 


### PR DESCRIPTION
Thanks @jonnilundy for finding this bug!