### PR TITLE
Moves tabindex manipulation inside Button component

### DIFF
--- a/packages/marble-button/demos/index.html
+++ b/packages/marble-button/demos/index.html
@@ -38,32 +38,26 @@
         <script>
           new metal.Button({
             label: 'Default',
-            tabIndex: -1,
           }, '#types');
           new metal.Button({
             label: 'Accent',
             style: 'accent',
-            tabIndex: -1,
           }, '#types');
           new metal.Button({
             label: 'Primary',
             style: 'primary',
-            tabIndex: -1,
           }, '#types');
           new metal.Button({
             label: 'Success',
             style: 'success',
-            tabIndex: -1,
           }, '#types');
           new metal.Button({
             label: 'Danger',
             style: 'danger',
-            tabIndex: -1,
           }, '#types');
           new metal.Button({
             label: 'Link',
             style: 'link',
-            tabIndex: -1,
           }, '#types');
         </script>
       </div>
@@ -74,21 +68,17 @@
           new metal.Button({
             label: 'x small',
             size: 'xs',
-            tabIndex: -1,
           }, '#sizes');
           new metal.Button({
             label: 'small',
             size: 'sm',
-            tabIndex: -1,
           }, '#sizes');
           new metal.Button({
             label: 'default',
-            tabIndex: -1,
           }, '#sizes');
           new metal.Button({
             label: 'large',
             size: 'lg',
-            tabIndex: -1,
           }, '#sizes');
         </script>
       </div>
@@ -99,14 +89,22 @@
           new metal.Button({
             disabled: true,
             label: 'disabled',
-            tabIndex: -1,
           }, '#disabled');
           new metal.Button({
             disabled: true,
             label: 'disabled',
             style: 'success',
-            tabIndex: -1,
           }, '#disabled');
+        </script>
+      </div>
+
+      <div id="focusTabIndex" class="body-section">
+        <h3 class="content-body-title">Without click-focus</h3>
+        <script>
+          new metal.Button({
+            label: 'Tab only to focus',
+            focusTabIndex: true,
+          }, '#focusTabIndex');
         </script>
       </div>
 
@@ -116,13 +114,11 @@
           new metal.Button({
             icon: 'icon-16-star',
             label: 'Icon Left',
-            tabIndex: -1,
           }, '#label-and-icon');
           new metal.Button({
             icon: 'icon-16-star',
             iconAlignment: 'right',
             label: 'Icon Right',
-            tabIndex: -1,
           }, '#label-and-icon');
         </script>
       </div>
@@ -133,7 +129,6 @@
           new metal.Button({
             icon: 'icon-12-alert',
             style: 'danger',
-            tabIndex: -1,
           }, '#only-icon');
         </script>
       </div>
@@ -145,13 +140,11 @@
             format: 'squared',
             icon: 'icon-12-alert',
             style: 'danger',
-            tabIndex: -1,
           }, '#format');
           new metal.Button({
             format: 'rounded',
             icon: 'icon-12-alert',
             style: 'danger',
-            tabIndex: -1,
           }, '#format');
         </script>
       </div>
@@ -164,7 +157,6 @@
             icon: 'icon-12-alert',
             label: 'Block',
             style: 'success',
-            tabIndex: -1,
           }, '#block');
         </script>
       </div>
@@ -180,7 +172,6 @@
             label: 'Click',
             style: 'success',
             click: 'clickFn',
-            tabIndex: -1,
           }, '#click');
         </script>
       </div>

--- a/packages/marble-button/src/Button.js
+++ b/packages/marble-button/src/Button.js
@@ -33,6 +33,12 @@ Button.STATE = {
   elementClasses: Config.string(),
 
   /**
+   * @default false
+   * @type {?boolean}
+   */
+  focusTabIndex: Config.bool().value(false),
+
+  /**
    * @default undefined
    * @type {?string}
    */
@@ -94,12 +100,6 @@ Button.STATE = {
   style: Config.oneOf(['accent', 'default', 'link', 'primary', 'success', 'danger', 'warning']).value(
     'default'
   ),
-
-  /**
-   * @default undefined
-   * @type {?(number|undefined)}
-   */
-  tabIndex: Config.number(),
 
   /**
    * @default undefined

--- a/packages/marble-button/src/Button.soy
+++ b/packages/marble-button/src/Button.soy
@@ -82,10 +82,6 @@
     {if not $href}
       type="{$type}"
     {/if}
-
-    {if $focusTabIndex}
-      tabindex="0"
-    {/if}
   {/let}
 
   {if $href}

--- a/packages/marble-button/src/Button.soy
+++ b/packages/marble-button/src/Button.soy
@@ -7,6 +7,7 @@
   {@param? block: bool}
   {@param? disabled: bool}
   {@param? elementClasses: string}
+  {@param? focusTabIndex: bool}
   {@param? format: string}
   {@param? href: string}
   {@param? icon: string}
@@ -17,7 +18,6 @@
   {@param? rel: string}
   {@param? size: string}
   {@param? style: string}
-  {@param? tabIndex: number}
   {@param? target: string}
   {@param? type: string}
   {@param? value: string}
@@ -44,6 +44,10 @@
         {sp}btn-{$style}
       {else}
         {sp}btn-default
+      {/if}
+
+      {if $focusTabIndex}
+        {sp}btn-tabindex-padding
       {/if}
     "
 
@@ -79,8 +83,8 @@
       type="{$type}"
     {/if}
 
-    {if $tabIndex}
-      tabIndex="{$tabIndex}"
+    {if $focusTabIndex}
+      tabindex="0"
     {/if}
   {/let}
 
@@ -89,11 +93,17 @@
   {else}
    <button {$attributes}>
   {/if}
-    {call .content}
-      {param icon: $icon /}
-      {param iconAlignment: $iconAlignment ?: 'left'/}
-      {param label: $label /}
-    {/call}
+    {if $focusTabIndex}
+      <div class="btn-tabindex-wrapper" tabindex="-1">
+    {/if}
+      {call .content}
+        {param icon: $icon /}
+        {param iconAlignment: $iconAlignment ?: 'left'/}
+        {param label: $label /}
+      {/call}
+    {if $focusTabIndex}
+      </div>
+    {/if}
   {if $href}
    </a>
   {else}

--- a/packages/marble/src/_buttons.scss
+++ b/packages/marble/src/_buttons.scss
@@ -1,7 +1,8 @@
 /* ==========================================================================
    Buttons
    ========================================================================== */
-.btn {
+.btn,
+.btn .btn-tabindex-wrapper {
   align-content: center;
   align-items: center;
   border-radius: $br-md;
@@ -19,11 +20,19 @@
   }
 }
 
+// Forces button element to zero padding when .btn-tabindex-wrapper is present, uses wrapper for padding and content styles
+.btn.btn-tabindex-padding {
+  padding: 0 !important;
+}
+
 /* Sizes
    ========================================================================== */
 .btn,
+.btn-tabindex-wrapper,
 .btn.btn-md,
-.btn.btn-medium {
+.btn.btn-medium,
+.btn.btn-md .btn-tabindex-wrapper,
+.btn.btn-medium .btn-tabindex-wrapper {
   height: $bps-md;
   font-size: 15px;
   line-height: $bps-md;
@@ -31,14 +40,18 @@
 }
 
 .btn.btn-lg,
-.btn.btn-large {
+.btn.btn-large,
+.btn.btn-lg .btn-tabindex-wrapper,
+.btn.btn-large .btn-tabindex-wrapper {
   font-size: 16px;
   height: $bps-lg;
   line-height: $bps-lg;
 }
 
 .btn.btn-sm,
-.btn.btn-small {
+.btn.btn-small,
+.btn.btn-sm .btn-tabindex-wrapper,
+.btn.btn-small .btn-tabindex-wrapper {
   height: $bps-sm;
   font-size: 14px;
   line-height: $bps-sm;
@@ -58,7 +71,9 @@
 }
 
 .btn.btn-ml,
-.btn.btn-mlarge {
+.btn.btn-mlarge,
+.btn.btn-ml .btn-tabindex-wrapper,
+.btn.btn-mlarge .btn-tabindex-wrapper {
   height: ($base * 7);
   font-size: 14px;
   line-height: ($base * 7);
@@ -78,7 +93,9 @@
 }
 
 .btn.btn-xs,
-.btn.btn-xsmall {
+.btn.btn-xsmall,
+.btn.btn-xs .btn-tabindex-wrapper,
+.btn.btn-xsmall .btn-tabindex-wrapper {
   height: $bps-xs;
   font-size: 12px;
   line-height: $bps-xs;
@@ -223,15 +240,18 @@
 
 /* icons
    ========================================================================== */
-.btn > .icon {
+.btn > .icon,
+.btn .btn-tabindex-wrapper > .icon {
   min-width: 16px;
 }
 
-.btn > .icon-left {
+.btn > .icon-left,
+.btn .btn-tabindex-wrapper > .icon-left {
   margin: 0 $base 0 0;
 }
 
-.btn > .icon-right {
+.btn > .icon-right,
+.btn .btn-tabindex-wrapper > .icon-right {
   margin: 0 0 0 $base;
 }
 
@@ -247,13 +267,16 @@
 
 /* format
    ========================================================================== */
-.btn.btn-block {
+.btn.btn-block,
+.btn.btn-block .btn-tabindex-wrapper {
   display: flex;
   width: 100%;
 }
 
 .btn.btn-rounded,
-.btn.btn-squared {
+.btn.btn-squared,
+.btn.btn-rounded .btn-tabindex-wrapper,
+.btn.btn-squared .btn-tabindex-wrapper {
   padding: 0;
   width: $bps-md;
 


### PR DESCRIPTION
@ygorcosta 
This is necessary because I realized that, under the old fix (https://github.com/wedeploy/marble/pull/126), our Button component will not inherit the "click" event from its parent when pressing enter after tabbing to it.

This fix will not break other buttons because it preserves the markup, but it allows us to update our styles on console to allow for `focusTabIndex`, which will prevent click-focus and only allow focus by tabbing.

This should not cause any regressions. Please let me know if you think of anything or have any changes!